### PR TITLE
Add maxissues threshold support for CI/CD rule enforcement

### DIFF
--- a/.asist.example.yaml
+++ b/.asist.example.yaml
@@ -49,6 +49,7 @@ ruleoverrides:
 # includepattern: specify file types to be scanned.
 # excludepattern: specify file types not to be scanned.
 # `enabled` property is used to enable/disable a custom rule.
+# `cicdmaxissues` property sets the maximum allowed issue count for this custom rule in CI/CD mode (default is 0).
 customregexrules:
   CustomRule1:
     name: customName1
@@ -59,6 +60,7 @@ customregexrules:
     pattern: Label
     includepattern: "\\.component$|\\.page$|\\.cls$|\\.email"
     excludepattern: ""
+    cicdmaxissues: 10  # Allow up to 10 CustomRule1 issues in CI/CD mode
   CustomRule2:
     name: customName2
     description: Please fix this custom rule

--- a/.asist.example.yaml
+++ b/.asist.example.yaml
@@ -19,16 +19,20 @@ dontforceignore: false
 cicdrules: 
   - "XSSLabel"
   - "XSSMergeField"
+  - "XSSTooltip"
 
 # `ruleoverrides` property is used to override some properties of standard rules. The following are defined below:
 # severity: Low|Medium|High|Critical
 # includepattern: specify files or folders to be included from scans.
 # excludepattern: specify files or folders to be excluded from scans.
 # `enabled` property is used to enable/disable a particular rule. It will override `enableAllStandardRules` property.
+# `maxissues` property sets maximum allowed issue count (default is 0 if not specified - no issues allowed).
+#   This is useful when introducing ASIST to a codebase with existing issues - you can gradually reduce maxissues.
 ruleoverrides:
   XSSTooltip: # Rule Id to be overriden
     severity: Medium
     enabled: true
+    maxissues: 50  # Allow up to 50 XSSTooltip issues (grandfathered existing issues)
   XSSLabel:
     includepattern: "\\.page$|\\.component$"
     enabled: true

--- a/.asist.example.yaml
+++ b/.asist.example.yaml
@@ -26,13 +26,13 @@ cicdrules:
 # includepattern: specify files or folders to be included from scans.
 # excludepattern: specify files or folders to be excluded from scans.
 # `enabled` property is used to enable/disable a particular rule. It will override `enableAllStandardRules` property.
-# `maxissues` property sets maximum allowed issue count (default is 0 if not specified - no issues allowed).
-#   This is useful when introducing ASIST to a codebase with existing issues - you can gradually reduce maxissues.
+# `cicdmaxissues` property sets maximum allowed issue count (default is 0 if not specified - no issues allowed).
+#   This is useful when introducing ASIST to a codebase with existing issues - you can gradually reduce cicdmaxissues.
 ruleoverrides:
   XSSTooltip: # Rule Id to be overriden
     severity: Medium
     enabled: true
-    maxissues: 50  # Allow up to 50 XSSTooltip issues (grandfathered existing issues)
+    cicdmaxissues: 50  # Allow up to 50 XSSTooltip issues (grandfathered existing issues)
   XSSLabel:
     includepattern: "\\.page$|\\.component$"
     enabled: true

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ This allows developers to add a subset of the overall ruleset to ASIST to their 
 
 ## Rule Max Issues
 
-When introducing ASIST to an existing codebase, you may have pre-existing security issues that you want to prevent from increasing while you work on fixing them. The `cicdmaxissues` property in [`ruleoverrides`](#-customizing-standard-rules) allows you to set maximum allowed issue counts for specific rules.
+When introducing ASIST to an existing codebase, you may have pre-existing security issues that you want to prevent from increasing while you work on fixing them. The `cicdmaxissues` property in [`ruleoverrides`](#-customizing-standard-rules) allows you to set maximum allowed issue counts for specific rules for CI/CD mode (with option -j ) scanning only. 
 
 **By default, rules have a limit of 0 issues.** When a rule exceeds its `cicdmaxissues` threshold, ASIST will exit with an error code (see [Exit Codes](#-exit-codes)). You only need to set `cicdmaxissues` if you want to allow existing issues while preventing them from growing.
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ customregexrules:
     pattern: "System\\.debug\\("
     includepattern: "\\.cls$"
     excludepattern: "Test\\.cls$"
+    cicdmaxissues: 10  # Allow up to 10 occurrences in CI/CD mode
 ```
 
 You can test this specific rule like this:
@@ -299,17 +300,31 @@ This allows developers to add a subset of the overall ruleset to ASIST to their 
 
 ## Rule Max Issues
 
-When introducing ASIST to an existing codebase, you may have pre-existing security issues that you want to prevent from increasing while you work on fixing them. The `cicdmaxissues` property in [`ruleoverrides`](#-customizing-standard-rules) allows you to set maximum allowed issue counts for specific rules for CI/CD mode (with option -j ) scanning only. 
+When introducing ASIST to an existing codebase, you may have pre-existing security issues that you want to prevent from increasing while you work on fixing them. The `cicdmaxissues` property allows you to set maximum allowed issue counts for specific rules for CI/CD mode (with option -j ) scanning only.
 
 **By default, rules have a limit of 0 issues.** When a rule exceeds its `cicdmaxissues` threshold, ASIST will exit with an error code (see [Exit Codes](#-exit-codes)). You only need to set `cicdmaxissues` if you want to allow existing issues while preventing them from growing.
+
+For **standard rules**, set `cicdmaxissues` under `ruleoverrides`:
 
 ```yaml
 ruleoverrides:
   XSSLabel:
-    cicdmaxissues: 150  # Allow up to 150 XSSTooltip issues (grandfather existing issues)
+    cicdmaxissues: 150  # Allow up to 150 XSSLabel issues (grandfather existing issues)
   XSSMergeField:
     cicdmaxissues: 0    # Explicitly set to 0 (same as default - no issues allowed)
   # XSSDomHtml has no cicdmaxissues set, defaults to 0 (no issues allowed)
+```
+
+For **custom rules**, set `cicdmaxissues` directly in the rule definition:
+
+```yaml
+customregexrules:
+  NoDebugStatements:
+    name: doNotDebug
+    severity: Critical
+    pattern: "System\\.debug\\("
+    includepattern: "\\.cls$"
+    cicdmaxissues: 20  # Allow up to 20 existing debug statements while you clean them up
 ```
 
 This feature allows you to:

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 </div>
 
 # ASIST (Automated Security Issue Scanning Tool)
+
 [![Go Reference](https://pkg.go.dev/badge/github.com/certinia/asist.svg)](https://pkg.go.dev/github.com/certinia/asist)
 [![License: BSD-3-Clause](https://img.shields.io/badge/license-BSD--3--Clause-blue)](https://opensource.org/license/bsd-3-clause)
 
-ASIST is a regex-based, blazing-fast Static Application Security Testing (SAST) tool for securing Salesforce apps at developer speed. 
+ASIST is a regex-based, blazing-fast Static Application Security Testing (SAST) tool for securing Salesforce apps at developer speed.
 
 Originally built for internal use at Certinia to support Security Reviews, we have now decided to release it to the community 🌍
 
@@ -25,7 +26,7 @@ Originally built for internal use at Certinia to support Security Reviews, we ha
 
 ## ▶️ VSCode extension demo
 
-![ASIST scan via Extension](images/scan-using-extension.gif) 
+![ASIST scan via Extension](images/scan-using-extension.gif)
 
 ## ▶️ CLI demo
 
@@ -59,7 +60,6 @@ Alternatively:
 - To just build the binary for your OS and architecture: `make`
 - To cross-compile: `GOOS=windows GOARCH=amd64 go build -o asist.exe .`
 - To build binaries for the most common platforms, run: `make build-binaries`
- 
 
 ## 🕹️ Usage
 
@@ -201,12 +201,12 @@ Configuration files can also be explicitly specified using the `-c` argument (no
 
 Within the config file, you can:
 
-* Enable/disable all the standard rules  
-* Override certain properties of standard rules
-* Exclude files or directories for all rules
-* Exclude files or directories for specific rules
-* Add custom regex rules
-* Define rules to be run in CI/CD mode
+- Enable/disable all the standard rules  
+- Override certain properties of standard rules
+- Exclude files or directories for all rules
+- Exclude files or directories for specific rules
+- Add custom regex rules
+- Define rules to be run in CI/CD mode
 
 See our [example config file](.asist.example.yaml) for a walkthrough of all config options.
 
@@ -215,6 +215,7 @@ See our [example config file](.asist.example.yaml) for a walkthrough of all conf
 Users can override certain properties of standard rules according to their needs, allowing them to customize the behavior of specific rules by:
 
 - Disabling rules entirely: `enabled`
+- Limiting the number of allowed rule violations: [`maxissues`](#rule-max-issues)
 - Tweaking rule severity: `severity`
 - Tweaking what files should be scanned: `includepattern`
 - Tweaking what files should not be scanned: `excludepattern`
@@ -237,7 +238,6 @@ customregexrules:
 ```
 
 You can test this specific rule like this:
-
 
 ```shell
 asist -c .asist.yaml -r doNotDebug <file>
@@ -292,11 +292,33 @@ In this mode, by default, all enabled runs will be run if `cicdrules` property i
 cicdrules: 
   - "XSSLabel"
   - "XSSMergeField"
+  - "XSSDomHtml"
 ```
 
 This allows developers to add a subset of the overall ruleset to ASIST to their CI/CD pipelines, and gradually add more rules to CI/CD as they start clearing out findings for other rules. This prevents any issues for rules defined in `cicdrules` from creeping back into the codebase.
 
-### 📊 Baseline scans
+## Rule Max Issues
+
+When introducing ASIST to an existing codebase, you may have pre-existing security issues that you want to prevent from increasing while you work on fixing them. The `maxissues` property in [`ruleoverrides`](#-customizing-standard-rules) allows you to set maximum allowed issue counts for specific rules.
+
+**By default, rules have a limit of 0 issues.** When a rule exceeds its `maxissues` threshold, ASIST will exit with an error code (see [Exit Codes](#-exit-codes)). You only need to set `maxissues` if you want to allow existing issues while preventing them from growing.
+
+```yaml
+ruleoverrides:
+  XSSLabel:
+    maxissues: 150  # Allow up to 150 XSSTooltip issues (grandfather existing issues)
+  XSSMergeField:
+    maxissues: 0    # Explicitly set to 0 (same as default - no issues allowed)
+  # XSSDomHtml has no maxissues set, defaults to 0 (no issues allowed)
+```
+
+This feature allows you to:
+
+- Gradually introduce stricter security requirements by lowering maxissues over time
+- Prevent technical debt from growing while you address existing issues  
+- Start enforcing security on a codebase with 150 existing issues, then reduce to 100, 50, and eventually 0
+
+## 📊 Baseline scans
 
 This mode is intended for SecOps teams to create benchmarks across multiple projects and measure the adoption of ASIST.
 
@@ -314,32 +336,32 @@ This command will output a JSON like this (when formatted):
 
 ```json
 [
-	{
-		"RepositoryName": "certinia/asist",
-		"RepositoryURL": "git@github.com:certinia/asist.git",
-		"RecordType": "Finding",
-		"Content": {
-			"FindingID": "b17fe249915712219aca7e",
-			"IsCustom": false,
-			"IsFalsePositive": true,
-			"RuleID": "LwcNonStandardPositioning",
-			"Severity": "Medium",
-			"RuleCategory": "Security"
-		}
-	},
-	{
-		"RepositoryName": "certinia/asist",
-		"RepositoryURL": "git@github.com:certinia/asist.git",
-		"RecordType": "Finding",
-		"Content": {
-			"FindingID": "3a2861bee641864816b86d",
-			"IsCustom": false,
-			"IsFalsePositive": true,
-			"RuleID": "LwcNonStandardPositioning",
-			"Severity": "Medium",
-			"RuleCategory": "Security"
-		}
-	}
+ {
+  "RepositoryName": "certinia/asist",
+  "RepositoryURL": "git@github.com:certinia/asist.git",
+  "RecordType": "Finding",
+  "Content": {
+   "FindingID": "b17fe249915712219aca7e",
+   "IsCustom": false,
+   "IsFalsePositive": true,
+   "RuleID": "LwcNonStandardPositioning",
+   "Severity": "Medium",
+   "RuleCategory": "Security"
+  }
+ },
+ {
+  "RepositoryName": "certinia/asist",
+  "RepositoryURL": "git@github.com:certinia/asist.git",
+  "RecordType": "Finding",
+  "Content": {
+   "FindingID": "3a2861bee641864816b86d",
+   "IsCustom": false,
+   "IsFalsePositive": true,
+   "RuleID": "LwcNonStandardPositioning",
+   "Severity": "Medium",
+   "RuleCategory": "Security"
+  }
+ }
 ]
 ```
 
@@ -350,8 +372,7 @@ A few differences can be observed compared to regular scans:
 - Each issue is assigned a `FindingID`, which is effectively a hash that uniquely identifies the finding based on the rule, the finding location, and if it's a false positive or not.
 - A few more properties are added, such as if the rule is custom, or if the finding is marked as false positive or not.
 
-
-### 🫣 .gitignore and .forceignore files
+## 🫣 .gitignore and .forceignore files
 
 By default, ASIST will ignore files and folders defined inside .gitignore and .forceignore. If you don't want ASIST to respect .gitignore and .forceignore, you can use the following properties in the config file:
 
@@ -366,7 +387,6 @@ By default, ASIST will ignore files and folders defined inside .gitignore and .f
 | 1         | ASIST executed successfully with findings                |
 | 3         | ASIST failed due to internal error (file a bug report!)  |
 | 4         | ASIST failed due to user error (review input and config) |
-
 
 ## 🏗️ [CONTRIBUTING](CONTRIBUTING.md)
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Configuration files can also be explicitly specified using the `-c` argument (no
 
 Within the config file, you can:
 
-- Enable/disable all the standard rules  
+- Enable/disable all the standard rules
 - Override certain properties of standard rules
 - Exclude files or directories for all rules
 - Exclude files or directories for specific rules
@@ -290,9 +290,9 @@ In this mode, by default, all enabled runs will be run if `cicdrules` property i
 
 ```yaml
 cicdrules: 
+  - "XSSDomHtml"
   - "XSSLabel"
   - "XSSMergeField"
-  - "XSSDomHtml"
 ```
 
 This allows developers to add a subset of the overall ruleset to ASIST to their CI/CD pipelines, and gradually add more rules to CI/CD as they start clearing out findings for other rules. This prevents any issues for rules defined in `cicdrules` from creeping back into the codebase.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ See our [example config file](.asist.example.yaml) for a walkthrough of all conf
 Users can override certain properties of standard rules according to their needs, allowing them to customize the behavior of specific rules by:
 
 - Disabling rules entirely: `enabled`
-- Limiting the number of allowed rule violations: [`maxissues`](#rule-max-issues)
+- Limiting the number of allowed rule violations: [`cicdmaxissues`](#rule-max-issues)
 - Tweaking rule severity: `severity`
 - Tweaking what files should be scanned: `includepattern`
 - Tweaking what files should not be scanned: `excludepattern`
@@ -299,22 +299,22 @@ This allows developers to add a subset of the overall ruleset to ASIST to their 
 
 ## Rule Max Issues
 
-When introducing ASIST to an existing codebase, you may have pre-existing security issues that you want to prevent from increasing while you work on fixing them. The `maxissues` property in [`ruleoverrides`](#-customizing-standard-rules) allows you to set maximum allowed issue counts for specific rules.
+When introducing ASIST to an existing codebase, you may have pre-existing security issues that you want to prevent from increasing while you work on fixing them. The `cicdmaxissues` property in [`ruleoverrides`](#-customizing-standard-rules) allows you to set maximum allowed issue counts for specific rules.
 
-**By default, rules have a limit of 0 issues.** When a rule exceeds its `maxissues` threshold, ASIST will exit with an error code (see [Exit Codes](#-exit-codes)). You only need to set `maxissues` if you want to allow existing issues while preventing them from growing.
+**By default, rules have a limit of 0 issues.** When a rule exceeds its `cicdmaxissues` threshold, ASIST will exit with an error code (see [Exit Codes](#-exit-codes)). You only need to set `cicdmaxissues` if you want to allow existing issues while preventing them from growing.
 
 ```yaml
 ruleoverrides:
   XSSLabel:
-    maxissues: 150  # Allow up to 150 XSSTooltip issues (grandfather existing issues)
+    cicdmaxissues: 150  # Allow up to 150 XSSTooltip issues (grandfather existing issues)
   XSSMergeField:
-    maxissues: 0    # Explicitly set to 0 (same as default - no issues allowed)
-  # XSSDomHtml has no maxissues set, defaults to 0 (no issues allowed)
+    cicdmaxissues: 0    # Explicitly set to 0 (same as default - no issues allowed)
+  # XSSDomHtml has no cicdmaxissues set, defaults to 0 (no issues allowed)
 ```
 
 This feature allows you to:
 
-- Gradually introduce stricter security requirements by lowering maxissues over time
+- Gradually introduce stricter security requirements by lowering cicdmaxissues over time
 - Prevent technical debt from growing while you address existing issues  
 - Start enforcing security on a codebase with 150 existing issues, then reduce to 100, 50, and eventually 0
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-* Added `maxissues` property to `ruleoverrides` config, allowing a maximum number of issues to be permitted per rule in CI/CD mode. This enables gradual remediation of existing issues by setting a threshold that can be reduced over time. Exceeding the threshold exits with a non-zero code and prints a violation summary to stderr.
+* Added property to `cicdmaxissues` in `ruleoverrides` config, allowing a maximum number of issues to be permitted per rule in CI/CD mode. This enables gradual remediation of existing issues by setting a threshold that can be reduced over time. Exceeding the threshold exits with a non-zero code and prints a violation summary to stderr.
+* When running `--list-rules`, each rule now displays its `CicdMaxIssues` value. Rules without a `cicdmaxissues` override show a default value of `0`.
 
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## \[Unreleased\]
 
+### Added
+
+* Added `maxissues` property to `ruleoverrides` config, allowing a maximum number of issues to be permitted per rule in CI/CD mode. This enables gradual remediation of existing issues by setting a threshold that can be reduced over time. Exceeding the threshold exits with a non-zero code and prints a violation summary to stderr.
+
 ### Fixed
 
 * Enhanced the regex to be case-insensitive and to support `.` in repository names, enabling correct extraction of the repository name from SSH URLs in baseline scan.

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * Added property to `cicdmaxissues` in `ruleoverrides` config, allowing a maximum number of issues to be permitted per rule in CI/CD mode. This enables gradual remediation of existing issues by setting a threshold that can be reduced over time. Exceeding the threshold exits with a non-zero code and prints a violation summary to stderr.
 * When running `--list-rules`, each rule now displays its `CicdMaxIssues` value. Rules without a `cicdmaxissues` override show a default value of `0`.
+* Added `cicdmaxissues` support to `customregexrules`, allowing custom rules to define their own CI/CD issue threshold directly in their rule definition.
 
 ### Fixed
 

--- a/config/config.go
+++ b/config/config.go
@@ -67,7 +67,7 @@ func ParseConfig(path string) (*Config, error) {
 }
 
 /**
-*	GetConfigFilePath - Returns the file path of the config file (JSON or YAML) if it exists, otherwise an empty string.
+ *	GetConfigFilePath - Returns the file path of the config file (JSON or YAML) if it exists, otherwise an empty string.
  */
 func GetConfigFilePath(rootPath string, configFilePath string, isBaselineEnabled bool) (string, error) {
 	if configFilePath != "" || !isBaselineEnabled {
@@ -88,7 +88,7 @@ func GetConfigFilePath(rootPath string, configFilePath string, isBaselineEnabled
 }
 
 /**
-*	FilterExcludedFilesAndFolders - Filter out the paths from the provided list that are present in the ExcludeFilesAndFolders property of config file.
+ *	FilterExcludedFilesAndFolders - Filter out the paths from the provided list that are present in the ExcludeFilesAndFolders property of config file.
  */
 func (c *Config) FilterExcludedFilesAndFolders(paths []string) []string {
 	var filteredPaths []string
@@ -130,10 +130,9 @@ func (c *Config) GetCICDRuleIds() []rules.RuleID {
 }
 
 /**
- * Returns the max allowed issues for a specific rule ID.
  * Returns ruleoverrides.<rule>.cicdmaxissues if set, otherwise 0.
  */
-func (c *Config) GetRuleMaxIssues(ruleId rules.RuleID) int {
+func (c *Config) GetRuleCicdMaxIssues(ruleId rules.RuleID) int {
 	if c == nil || c.RuleOverrides == nil {
 		return 0
 	}
@@ -149,8 +148,8 @@ func (c *Config) GetRuleMaxIssues(ruleId rules.RuleID) int {
 }
 
 /**
-* GetEnabledOverridedStandardRuleIds - Return the standard rule Ids
-*	Where RuleOveride property is defined and override rules enabled property is set to true or nil
+ * GetEnabledOverridedStandardRuleIds - Return the standard rule Ids
+ *	Where RuleOveride property is defined and override rules enabled property is set to true or nil
  */
 func (c *Config) GetEnabledOverridedStandardRuleIds(standarRuleIds []rules.RuleID) []rules.RuleID {
 	enabledRuleIds := []rules.RuleID{}

--- a/config/config.go
+++ b/config/config.go
@@ -130,6 +130,25 @@ func (c *Config) GetCICDRuleIds() []rules.RuleID {
 }
 
 /**
+ * Returns the max allowed issues for a specific rule ID.
+ * Returns ruleoverrides.<rule>.maxissues if set, otherwise 0.
+ */
+func (c *Config) GetRuleMaxIssues(ruleId rules.RuleID) int {
+	if c == nil || c.RuleOverrides == nil {
+		return 0
+	}
+	
+	// Check if maxissues is explicitly set in ruleoverrides
+	if override, exists := c.RuleOverrides[string(ruleId)]; exists {
+		if override.MaxIssues != nil {
+			return *override.MaxIssues
+		}
+	}
+	
+	return 0
+}
+
+/**
 * GetEnabledOverridedStandardRuleIds - Return the standard rule Ids
 *	Where RuleOveride property is defined and override rules enabled property is set to true or nil
  */

--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,7 @@ type CustomRegexRule struct {
 	Pattern        string
 	IncludePattern string
 	ExcludePattern string
+	CicdMaxIssues  *int
 }
 
 var config *Config
@@ -130,20 +131,29 @@ func (c *Config) GetCICDRuleIds() []rules.RuleID {
 }
 
 /**
- * Returns ruleoverrides.<rule>.cicdmaxissues if set, otherwise 0.
+ * Returns the cicdmaxissues threshold for a rule.
+ * Checks ruleoverrides first (standard rules), then customregexrules (custom rules).
+ * Returns 0 if not set.
  */
 func (c *Config) GetRuleCicdMaxIssues(ruleId rules.RuleID) int {
-	if c == nil || c.RuleOverrides == nil {
+	if c == nil {
 		return 0
 	}
-	
-	// Check if cicdmaxissues is explicitly set in ruleoverrides
+
+	// Check standard rule overrides
 	if override, exists := c.RuleOverrides[string(ruleId)]; exists {
 		if override.CicdMaxIssues != nil {
 			return *override.CicdMaxIssues
 		}
 	}
-	
+
+	// Check custom rules
+	if customRule, exists := c.CustomRegexRules[string(ruleId)]; exists {
+		if customRule.CicdMaxIssues != nil {
+			return *customRule.CicdMaxIssues
+		}
+	}
+
 	return 0
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -131,17 +131,17 @@ func (c *Config) GetCICDRuleIds() []rules.RuleID {
 
 /**
  * Returns the max allowed issues for a specific rule ID.
- * Returns ruleoverrides.<rule>.maxissues if set, otherwise 0.
+ * Returns ruleoverrides.<rule>.cicdmaxissues if set, otherwise 0.
  */
 func (c *Config) GetRuleMaxIssues(ruleId rules.RuleID) int {
 	if c == nil || c.RuleOverrides == nil {
 		return 0
 	}
 	
-	// Check if maxissues is explicitly set in ruleoverrides
+	// Check if cicdmaxissues is explicitly set in ruleoverrides
 	if override, exists := c.RuleOverrides[string(ruleId)]; exists {
-		if override.MaxIssues != nil {
-			return *override.MaxIssues
+		if override.CicdMaxIssues != nil {
+			return *override.CicdMaxIssues
 		}
 	}
 	

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -483,12 +483,12 @@ func TestGetEnabledCustomRuleIds_WhenCustomRulesNotEmpty_ReturnsRuleIds(t *testi
 	}
 }
 
-func TestGetRuleMaxIssues_WhenConfigNil_ReturnsZero(t *testing.T) {
+func TestGetRuleCicdMaxIssues_WhenConfigNil_ReturnsZero(t *testing.T) {
 	//Given
 	var configFile *Config
 
 	//When
-	actualResult := configFile.GetRuleMaxIssues("SomeRule")
+	actualResult := configFile.GetRuleCicdMaxIssues("SomeRule")
 
 	//Then
 	if actualResult != 0 {
@@ -496,14 +496,14 @@ func TestGetRuleMaxIssues_WhenConfigNil_ReturnsZero(t *testing.T) {
 	}
 }
 
-func TestGetRuleMaxIssues_WhenRuleOverridesNil_ReturnsZero(t *testing.T) {
+func TestGetRuleCicdMaxIssues_WhenRuleOverridesNil_ReturnsZero(t *testing.T) {
 	//Given
 	configFile := &Config{
 		RuleOverrides: nil,
 	}
 
 	//When
-	actualResult := configFile.GetRuleMaxIssues("SomeRule")
+	actualResult := configFile.GetRuleCicdMaxIssues("SomeRule")
 
 	//Then
 	if actualResult != 0 {
@@ -511,7 +511,7 @@ func TestGetRuleMaxIssues_WhenRuleOverridesNil_ReturnsZero(t *testing.T) {
 	}
 }
 
-func TestGetRuleMaxIssues_WhenRuleNotInOverrides_ReturnsZero(t *testing.T) {
+func TestGetRuleCicdMaxIssues_WhenRuleNotInOverrides_ReturnsZero(t *testing.T) {
 	//Given
 	ENABLE := true
 	configFile := &Config{
@@ -523,7 +523,7 @@ func TestGetRuleMaxIssues_WhenRuleNotInOverrides_ReturnsZero(t *testing.T) {
 	}
 
 	//When
-	actualResult := configFile.GetRuleMaxIssues("SomeRule")
+	actualResult := configFile.GetRuleCicdMaxIssues("SomeRule")
 
 	//Then
 	if actualResult != 0 {
@@ -531,7 +531,7 @@ func TestGetRuleMaxIssues_WhenRuleNotInOverrides_ReturnsZero(t *testing.T) {
 	}
 }
 
-func TestGetRuleMaxIssues_WhenMaxIssuesNil_ReturnsZero(t *testing.T) {
+func TestGetRuleCicdMaxIssues_WhenMaxIssuesNil_ReturnsZero(t *testing.T) {
 	//Given
 	ENABLE := true
 	configFile := &Config{
@@ -544,7 +544,7 @@ func TestGetRuleMaxIssues_WhenMaxIssuesNil_ReturnsZero(t *testing.T) {
 	}
 
 	//When
-	actualResult := configFile.GetRuleMaxIssues("XSSTooltip")
+	actualResult := configFile.GetRuleCicdMaxIssues("XSSTooltip")
 
 	//Then
 	if actualResult != 0 {
@@ -552,7 +552,7 @@ func TestGetRuleMaxIssues_WhenMaxIssuesNil_ReturnsZero(t *testing.T) {
 	}
 }
 
-func TestGetRuleMaxIssues_WhenMaxIssuesExplicitlyZero_ReturnsZero(t *testing.T) {
+func TestGetRuleCicdMaxIssues_WhenMaxIssuesExplicitlyZero_ReturnsZero(t *testing.T) {
 	//Given
 	MAX_ISSUES_ZERO := 0
 	configFile := &Config{
@@ -564,7 +564,7 @@ func TestGetRuleMaxIssues_WhenMaxIssuesExplicitlyZero_ReturnsZero(t *testing.T) 
 	}
 
 	//When
-	actualResult := configFile.GetRuleMaxIssues("XSSTooltip")
+	actualResult := configFile.GetRuleCicdMaxIssues("XSSTooltip")
 
 	//Then
 	if actualResult != 0 {
@@ -572,7 +572,7 @@ func TestGetRuleMaxIssues_WhenMaxIssuesExplicitlyZero_ReturnsZero(t *testing.T) 
 	}
 }
 
-func TestGetRuleMaxIssues_WhenMaxIssuesSet_ReturnsValue(t *testing.T) {
+func TestGetRuleCicdMaxIssues_WhenMaxIssuesSet_ReturnsValue(t *testing.T) {
 	//Given
 	MAX_ISSUES := 50
 	configFile := &Config{
@@ -584,7 +584,7 @@ func TestGetRuleMaxIssues_WhenMaxIssuesSet_ReturnsValue(t *testing.T) {
 	}
 
 	//When
-	actualResult := configFile.GetRuleMaxIssues("XSSTooltip")
+	actualResult := configFile.GetRuleCicdMaxIssues("XSSTooltip")
 
 	//Then
 	if actualResult != 50 {
@@ -592,7 +592,7 @@ func TestGetRuleMaxIssues_WhenMaxIssuesSet_ReturnsValue(t *testing.T) {
 	}
 }
 
-func TestGetRuleMaxIssues_WhenParsedFromYAML_ReturnsValue(t *testing.T) {
+func TestGetRuleCicdMaxIssues_WhenParsedFromYAML_ReturnsValue(t *testing.T) {
 	//Given
 	const MOCK_CONFIG_FILE_PATH = "./testData/config.yaml"
 	configFile, err := ParseConfig(MOCK_CONFIG_FILE_PATH)
@@ -601,7 +601,7 @@ func TestGetRuleMaxIssues_WhenParsedFromYAML_ReturnsValue(t *testing.T) {
 	}
 
 	//When
-	actualResult := configFile.GetRuleMaxIssues("XSSTooltip")
+	actualResult := configFile.GetRuleCicdMaxIssues("XSSTooltip")
 
 	//Then
 	if actualResult != 10 {
@@ -609,7 +609,7 @@ func TestGetRuleMaxIssues_WhenParsedFromYAML_ReturnsValue(t *testing.T) {
 	}
 }
 
-func TestGetRuleMaxIssues_WhenParsedFromJSON_ReturnsValue(t *testing.T) {
+func TestGetRuleCicdMaxIssues_WhenParsedFromJSON_ReturnsValue(t *testing.T) {
 	//Given
 	const MOCK_CONFIG_FILE_PATH = "./testData/config.json"
 	configFile, err := ParseConfig(MOCK_CONFIG_FILE_PATH)
@@ -618,7 +618,7 @@ func TestGetRuleMaxIssues_WhenParsedFromJSON_ReturnsValue(t *testing.T) {
 	}
 
 	//When
-	actualResult := configFile.GetRuleMaxIssues("XSSTooltip")
+	actualResult := configFile.GetRuleCicdMaxIssues("XSSTooltip")
 
 	//Then
 	if actualResult != 10 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -16,6 +16,7 @@ func TestParseConfig_WhenYAMLConfigFileExist_ReturnsConfigInstance(t *testing.T)
 	ENABLED_TRUE := true
 	ENABLED_FALSE := false
 	MAX_ISSUES_10 := 10
+	CUSTOM_MAX_5 := 5
 
 	expectedConfigFile := Config{
 		EnableAllStandardRules: &ENABLED_TRUE,
@@ -39,6 +40,7 @@ func TestParseConfig_WhenYAMLConfigFileExist_ReturnsConfigInstance(t *testing.T)
 				Pattern:        "Label",
 				IncludePattern: "\\.component$|\\.page$|\\.cls$|\\.email",
 				ExcludePattern: "",
+				CicdMaxIssues:  &CUSTOM_MAX_5,
 			},
 		},
 		CICDRules: []string{
@@ -95,6 +97,7 @@ func TestParseConfig_WhenJSONConfigFileExist_ReturnsConfigInstance(t *testing.T)
 	ENABLED_TRUE := true
 	ENABLED_FALSE := false
 	MAX_ISSUES_10 := 10
+	CUSTOM_MAX_5 := 5
 
 	expectedConfigFile := Config{
 		EnableAllStandardRules: &ENABLED_TRUE,
@@ -118,6 +121,7 @@ func TestParseConfig_WhenJSONConfigFileExist_ReturnsConfigInstance(t *testing.T)
 				Pattern:        "Label",
 				IncludePattern: "\\.component$|\\.page$|\\.cls$|\\.email",
 				ExcludePattern: "",
+				CicdMaxIssues:  &CUSTOM_MAX_5,
 			},
 		},
 		CICDRules: []string{
@@ -623,5 +627,77 @@ func TestGetRuleCicdMaxIssues_WhenParsedFromJSON_ReturnsValue(t *testing.T) {
 	//Then
 	if actualResult != 10 {
 		t.Errorf("Expected 10 from JSON config, got %d", actualResult)
+	}
+}
+func TestGetRuleCicdMaxIssues_WhenCustomRuleHasCicdMaxIssues_ReturnsValue(t *testing.T) {
+	//Given
+	MAX_ISSUES := 25
+	configFile := &Config{
+		CustomRegexRules: map[string]CustomRegexRule{
+			"MyCustomRule": {
+				CicdMaxIssues: &MAX_ISSUES,
+			},
+		},
+	}
+
+	//When
+	actualResult := configFile.GetRuleCicdMaxIssues("MyCustomRule")
+
+	//Then
+	if actualResult != 25 {
+		t.Errorf("Expected 25 for custom rule cicdmaxissues, got %d", actualResult)
+	}
+}
+
+func TestGetRuleCicdMaxIssues_WhenCustomRuleHasNoCicdMaxIssues_ReturnsZero(t *testing.T) {
+	//Given
+	configFile := &Config{
+		CustomRegexRules: map[string]CustomRegexRule{
+			"MyCustomRule": {
+				Name: "MyCustomRule",
+			},
+		},
+	}
+
+	//When
+	actualResult := configFile.GetRuleCicdMaxIssues("MyCustomRule")
+
+	//Then
+	if actualResult != 0 {
+		t.Errorf("Expected 0 when custom rule has no cicdmaxissues, got %d", actualResult)
+	}
+}
+
+func TestGetRuleCicdMaxIssues_WhenCustomRuleParsedFromYAML_ReturnsValue(t *testing.T) {
+	//Given
+	const MOCK_CONFIG_FILE_PATH = "./testData/config.yaml"
+	configFile, err := ParseConfig(MOCK_CONFIG_FILE_PATH)
+	if err != nil {
+		t.Fatalf("Failed to parse config: %v", err)
+	}
+
+	//When
+	actualResult := configFile.GetRuleCicdMaxIssues("CustomRule1")
+
+	//Then
+	if actualResult != 5 {
+		t.Errorf("Expected 5 from YAML custom rule cicdmaxissues, got %d", actualResult)
+	}
+}
+
+func TestGetRuleCicdMaxIssues_WhenCustomRuleParsedFromJSON_ReturnsValue(t *testing.T) {
+	//Given
+	const MOCK_CONFIG_FILE_PATH = "./testData/config.json"
+	configFile, err := ParseConfig(MOCK_CONFIG_FILE_PATH)
+	if err != nil {
+		t.Fatalf("Failed to parse config: %v", err)
+	}
+
+	//When
+	actualResult := configFile.GetRuleCicdMaxIssues("CustomRule1")
+
+	//Then
+	if actualResult != 5 {
+		t.Errorf("Expected 5 from JSON custom rule cicdmaxissues, got %d", actualResult)
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,9 +24,9 @@ func TestParseConfig_WhenYAMLConfigFileExist_ReturnsConfigInstance(t *testing.T)
 		ExcludeFilesAndFolders: []string{"/force-app-autotests/"},
 		RuleOverrides: map[string]rules.RuleMetadataOverride{
 			"XSSTooltip": {
-				Severity:  "Medium",
-				Enabled:   &ENABLED_TRUE,
-				MaxIssues: &MAX_ISSUES_10,
+				Severity:      "Medium",
+				Enabled:       &ENABLED_TRUE,
+				CicdMaxIssues: &MAX_ISSUES_10,
 			},
 		},
 		CustomRegexRules: map[string]CustomRegexRule{
@@ -103,9 +103,9 @@ func TestParseConfig_WhenJSONConfigFileExist_ReturnsConfigInstance(t *testing.T)
 		ExcludeFilesAndFolders: []string{"/force-app-autotests/"},
 		RuleOverrides: map[string]rules.RuleMetadataOverride{
 			"XSSTooltip": {
-				Severity:  "Medium",
-				Enabled:   &ENABLED_TRUE,
-				MaxIssues: &MAX_ISSUES_10,
+				Severity:      "Medium",
+				Enabled:       &ENABLED_TRUE,
+				CicdMaxIssues: &MAX_ISSUES_10,
 			},
 		},
 		CustomRegexRules: map[string]CustomRegexRule{
@@ -548,7 +548,7 @@ func TestGetRuleMaxIssues_WhenMaxIssuesNil_ReturnsZero(t *testing.T) {
 
 	//Then
 	if actualResult != 0 {
-		t.Errorf("Expected 0 when MaxIssues is nil, got %d", actualResult)
+		t.Errorf("Expected 0 when CicdMaxIssues is nil, got %d", actualResult)
 	}
 }
 
@@ -558,7 +558,7 @@ func TestGetRuleMaxIssues_WhenMaxIssuesExplicitlyZero_ReturnsZero(t *testing.T) 
 	configFile := &Config{
 		RuleOverrides: map[string]rules.RuleMetadataOverride{
 			"XSSTooltip": {
-				MaxIssues: &MAX_ISSUES_ZERO,
+				CicdMaxIssues: &MAX_ISSUES_ZERO,
 			},
 		},
 	}
@@ -568,7 +568,7 @@ func TestGetRuleMaxIssues_WhenMaxIssuesExplicitlyZero_ReturnsZero(t *testing.T) 
 
 	//Then
 	if actualResult != 0 {
-		t.Errorf("Expected 0 when MaxIssues is explicitly 0, got %d", actualResult)
+		t.Errorf("Expected 0 when CicdMaxIssues is explicitly 0, got %d", actualResult)
 	}
 }
 
@@ -578,7 +578,7 @@ func TestGetRuleMaxIssues_WhenMaxIssuesSet_ReturnsValue(t *testing.T) {
 	configFile := &Config{
 		RuleOverrides: map[string]rules.RuleMetadataOverride{
 			"XSSTooltip": {
-				MaxIssues: &MAX_ISSUES,
+				CicdMaxIssues: &MAX_ISSUES,
 			},
 		},
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,6 +15,7 @@ func TestParseConfig_WhenYAMLConfigFileExist_ReturnsConfigInstance(t *testing.T)
 
 	ENABLED_TRUE := true
 	ENABLED_FALSE := false
+	MAX_ISSUES_10 := 10
 
 	expectedConfigFile := Config{
 		EnableAllStandardRules: &ENABLED_TRUE,
@@ -23,8 +24,9 @@ func TestParseConfig_WhenYAMLConfigFileExist_ReturnsConfigInstance(t *testing.T)
 		ExcludeFilesAndFolders: []string{"/force-app-autotests/"},
 		RuleOverrides: map[string]rules.RuleMetadataOverride{
 			"XSSTooltip": {
-				Severity: "Medium",
-				Enabled:  &ENABLED_TRUE,
+				Severity:  "Medium",
+				Enabled:   &ENABLED_TRUE,
+				MaxIssues: &MAX_ISSUES_10,
 			},
 		},
 		CustomRegexRules: map[string]CustomRegexRule{
@@ -92,6 +94,7 @@ func TestParseConfig_WhenJSONConfigFileExist_ReturnsConfigInstance(t *testing.T)
 	const MOCK_CONFIG_FILE_PATH = "./testData/config.json"
 	ENABLED_TRUE := true
 	ENABLED_FALSE := false
+	MAX_ISSUES_10 := 10
 
 	expectedConfigFile := Config{
 		EnableAllStandardRules: &ENABLED_TRUE,
@@ -100,8 +103,9 @@ func TestParseConfig_WhenJSONConfigFileExist_ReturnsConfigInstance(t *testing.T)
 		ExcludeFilesAndFolders: []string{"/force-app-autotests/"},
 		RuleOverrides: map[string]rules.RuleMetadataOverride{
 			"XSSTooltip": {
-				Severity: "Medium",
-				Enabled:  &ENABLED_TRUE,
+				Severity:  "Medium",
+				Enabled:   &ENABLED_TRUE,
+				MaxIssues: &MAX_ISSUES_10,
 			},
 		},
 		CustomRegexRules: map[string]CustomRegexRule{
@@ -476,5 +480,148 @@ func TestGetEnabledCustomRuleIds_WhenCustomRulesNotEmpty_ReturnsRuleIds(t *testi
 	//Then
 	if !reflect.DeepEqual(actualResult, expectedResult) {
 		t.Errorf("%s Actual: %+v, Expected: %+v", "Custom Regex Rule Ids are mismatched!!", actualResult, expectedResult)
+	}
+}
+
+func TestGetRuleMaxIssues_WhenConfigNil_ReturnsZero(t *testing.T) {
+	//Given
+	var configFile *Config
+
+	//When
+	actualResult := configFile.GetRuleMaxIssues("SomeRule")
+
+	//Then
+	if actualResult != 0 {
+		t.Errorf("Expected 0, got %d", actualResult)
+	}
+}
+
+func TestGetRuleMaxIssues_WhenRuleOverridesNil_ReturnsZero(t *testing.T) {
+	//Given
+	configFile := &Config{
+		RuleOverrides: nil,
+	}
+
+	//When
+	actualResult := configFile.GetRuleMaxIssues("SomeRule")
+
+	//Then
+	if actualResult != 0 {
+		t.Errorf("Expected 0, got %d", actualResult)
+	}
+}
+
+func TestGetRuleMaxIssues_WhenRuleNotInOverrides_ReturnsZero(t *testing.T) {
+	//Given
+	ENABLE := true
+	configFile := &Config{
+		RuleOverrides: map[string]rules.RuleMetadataOverride{
+			"OtherRule": {
+				Enabled: &ENABLE,
+			},
+		},
+	}
+
+	//When
+	actualResult := configFile.GetRuleMaxIssues("SomeRule")
+
+	//Then
+	if actualResult != 0 {
+		t.Errorf("Expected 0, got %d", actualResult)
+	}
+}
+
+func TestGetRuleMaxIssues_WhenMaxIssuesNil_ReturnsZero(t *testing.T) {
+	//Given
+	ENABLE := true
+	configFile := &Config{
+		RuleOverrides: map[string]rules.RuleMetadataOverride{
+			"XSSTooltip": {
+				Severity: "Medium",
+				Enabled:  &ENABLE,
+			},
+		},
+	}
+
+	//When
+	actualResult := configFile.GetRuleMaxIssues("XSSTooltip")
+
+	//Then
+	if actualResult != 0 {
+		t.Errorf("Expected 0 when MaxIssues is nil, got %d", actualResult)
+	}
+}
+
+func TestGetRuleMaxIssues_WhenMaxIssuesExplicitlyZero_ReturnsZero(t *testing.T) {
+	//Given
+	MAX_ISSUES_ZERO := 0
+	configFile := &Config{
+		RuleOverrides: map[string]rules.RuleMetadataOverride{
+			"XSSTooltip": {
+				MaxIssues: &MAX_ISSUES_ZERO,
+			},
+		},
+	}
+
+	//When
+	actualResult := configFile.GetRuleMaxIssues("XSSTooltip")
+
+	//Then
+	if actualResult != 0 {
+		t.Errorf("Expected 0 when MaxIssues is explicitly 0, got %d", actualResult)
+	}
+}
+
+func TestGetRuleMaxIssues_WhenMaxIssuesSet_ReturnsValue(t *testing.T) {
+	//Given
+	MAX_ISSUES := 50
+	configFile := &Config{
+		RuleOverrides: map[string]rules.RuleMetadataOverride{
+			"XSSTooltip": {
+				MaxIssues: &MAX_ISSUES,
+			},
+		},
+	}
+
+	//When
+	actualResult := configFile.GetRuleMaxIssues("XSSTooltip")
+
+	//Then
+	if actualResult != 50 {
+		t.Errorf("Expected 50, got %d", actualResult)
+	}
+}
+
+func TestGetRuleMaxIssues_WhenParsedFromYAML_ReturnsValue(t *testing.T) {
+	//Given
+	const MOCK_CONFIG_FILE_PATH = "./testData/config.yaml"
+	configFile, err := ParseConfig(MOCK_CONFIG_FILE_PATH)
+	if err != nil {
+		t.Fatalf("Failed to parse config: %v", err)
+	}
+
+	//When
+	actualResult := configFile.GetRuleMaxIssues("XSSTooltip")
+
+	//Then
+	if actualResult != 10 {
+		t.Errorf("Expected 10 from YAML config, got %d", actualResult)
+	}
+}
+
+func TestGetRuleMaxIssues_WhenParsedFromJSON_ReturnsValue(t *testing.T) {
+	//Given
+	const MOCK_CONFIG_FILE_PATH = "./testData/config.json"
+	configFile, err := ParseConfig(MOCK_CONFIG_FILE_PATH)
+	if err != nil {
+		t.Fatalf("Failed to parse config: %v", err)
+	}
+
+	//When
+	actualResult := configFile.GetRuleMaxIssues("XSSTooltip")
+
+	//Then
+	if actualResult != 10 {
+		t.Errorf("Expected 10 from JSON config, got %d", actualResult)
 	}
 }

--- a/config/testData/config.json
+++ b/config/testData/config.json
@@ -11,7 +11,8 @@
 	"ruleoverrides": {
 		"XSSTooltip": {
 			"severity": "Medium",
-			"enabled": true
+			"enabled": true,
+			"maxissues": 10
 		}
 	},
 	"customregexrules": {

--- a/config/testData/config.json
+++ b/config/testData/config.json
@@ -12,7 +12,7 @@
 		"XSSTooltip": {
 			"severity": "Medium",
 			"enabled": true,
-			"maxissues": 10
+			"cicdmaxissues": 10
 		}
 	},
 	"customregexrules": {

--- a/config/testData/config.json
+++ b/config/testData/config.json
@@ -24,7 +24,8 @@
 			"rulecategory": "Security",
 			"pattern": "Label",
 			"includepattern": "\\.component$|\\.page$|\\.cls$|\\.email",
-			"excludepattern": ""
+			"excludepattern": "",
+			"cicdmaxissues": 5
 		}
 	}
 }

--- a/config/testData/config.yaml
+++ b/config/testData/config.yaml
@@ -12,6 +12,7 @@ ruleoverrides:
   XSSTooltip:
     severity: Medium
     enabled: true
+    maxissues: 10
 
 customregexrules:
   CustomRule1:

--- a/config/testData/config.yaml
+++ b/config/testData/config.yaml
@@ -12,7 +12,7 @@ ruleoverrides:
   XSSTooltip:
     severity: Medium
     enabled: true
-    maxissues: 10
+    cicdmaxissues: 10
 
 customregexrules:
   CustomRule1:

--- a/config/testData/config.yaml
+++ b/config/testData/config.yaml
@@ -24,3 +24,4 @@ customregexrules:
     pattern: Label
     includepattern: "\\.component$|\\.page$|\\.cls$|\\.email"
     excludepattern: ""
+    cicdmaxissues: 5

--- a/docs/index.md
+++ b/docs/index.md
@@ -280,9 +280,9 @@ In this mode, by default, all enabled runs will be run if `cicdrules` property i
 
 ```yaml
 cicdrules:
+  - "XSSDomHtml"
   - "XSSLabel"
   - "XSSMergeField"
-  - "XSSDomHtml"
 ```
 
 This allows developers to add a subset of the overall ruleset to ASIST to their CI/CD pipelines, and gradually add more rules to CI/CD as they start clearing out findings for other rules. This prevents any issues for rules defined in `cicdrules` from creeping back into the codebase.

--- a/docs/index.md
+++ b/docs/index.md
@@ -231,6 +231,7 @@ customregexrules:
     pattern: "System\\.debug\\("
     includepattern: "\\.cls$"
     excludepattern: "Test\\.cls$"
+    cicdmaxissues: 10  # Allow up to 10 occurrences in CI/CD mode
 ```
 
 You can test this specific rule like this:
@@ -289,17 +290,31 @@ This allows developers to add a subset of the overall ruleset to ASIST to their 
 
 ## Rule Max Issues
 
-When introducing ASIST to an existing codebase, you may have pre-existing security issues that you want to prevent from increasing while you work on fixing them. The `cicdmaxissues` property in [`ruleoverrides`](#-customizing-standard-rules) allows you to set maximum allowed issue counts for specific rules for CI/CD mode (with option -j) scanning only.
+When introducing ASIST to an existing codebase, you may have pre-existing security issues that you want to prevent from increasing while you work on fixing them. The `cicdmaxissues` property allows you to set maximum allowed issue counts for specific rules for CI/CD mode (with option -j) scanning only.
 
 **By default, rules have a limit of 0 issues.** When a rule exceeds its `cicdmaxissues` threshold, ASIST will exit with an error code (see [Exit Codes](#-exit-codes)). You only need to set `cicdmaxissues` if you want to allow existing issues while preventing them from growing.
+
+For **standard rules**, set `cicdmaxissues` under `ruleoverrides`:
 
 ```yaml
 ruleoverrides:
   XSSLabel:
-    cicdmaxissues: 150  # Allow up to 150 XSSTooltip issues (grandfather existing issues)
+    cicdmaxissues: 150  # Allow up to 150 XSSLabel issues (grandfather existing issues)
   XSSMergeField:
     cicdmaxissues: 0    # Explicitly set to 0 (same as default - no issues allowed)
   # XSSDomHtml has no cicdmaxissues set, defaults to 0 (no issues allowed)
+```
+
+For **custom rules**, set `cicdmaxissues` directly in the rule definition:
+
+```yaml
+customregexrules:
+  NoDebugStatements:
+    name: doNotDebug
+    severity: Critical
+    pattern: "System\\.debug\\("
+    includepattern: "\\.cls$"
+    cicdmaxissues: 20  # Allow up to 20 existing debug statements while you clean them up
 ```
 
 This feature allows you to:

--- a/docs/index.md
+++ b/docs/index.md
@@ -211,7 +211,7 @@ See our [example config file](https://github.com/certinia/asist/blob/main/.asist
 Users can override certain properties of standard rules according to their needs, allowing them to customize the behavior of specific rules by:
 
 - Disabling rules entirely: `enabled`
-- Limiting the number of allowed rule violations: [`maxissues`](#rule-max-issues)
+- Limiting the number of allowed rule violations: [`cicdmaxissues`](#rule-max-issues)
 - Tweaking rule severity: `severity`
 - Tweaking what files should be scanned: `includepattern`
 - Tweaking what files should not be scanned: `excludepattern`
@@ -289,22 +289,22 @@ This allows developers to add a subset of the overall ruleset to ASIST to their 
 
 ## Rule Max Issues
 
-When introducing ASIST to an existing codebase, you may have pre-existing security issues that you want to prevent from increasing while you work on fixing them. The `maxissues` property in [`ruleoverrides`](#-customizing-standard-rules) allows you to set maximum allowed issue counts for specific rules.
+When introducing ASIST to an existing codebase, you may have pre-existing security issues that you want to prevent from increasing while you work on fixing them. The `cicdmaxissues` property in [`ruleoverrides`](#-customizing-standard-rules) allows you to set maximum allowed issue counts for specific rules.
 
-**By default, rules have a limit of 0 issues.** When a rule exceeds its `maxissues` threshold, ASIST will exit with an error code (see [Exit Codes](#-exit-codes)). You only need to set `maxissues` if you want to allow existing issues while preventing them from growing.
+**By default, rules have a limit of 0 issues.** When a rule exceeds its `cicdmaxissues` threshold, ASIST will exit with an error code (see [Exit Codes](#-exit-codes)). You only need to set `cicdmaxissues` if you want to allow existing issues while preventing them from growing.
 
 ```yaml
 ruleoverrides:
   XSSLabel:
-    maxissues: 150  # Allow up to 150 XSSTooltip issues (grandfather existing issues)
+    cicdmaxissues: 150  # Allow up to 150 XSSTooltip issues (grandfather existing issues)
   XSSMergeField:
-    maxissues: 0    # Explicitly set to 0 (same as default - no issues allowed)
-  # XSSDomHtml has no maxissues set, defaults to 0 (no issues allowed)
+    cicdmaxissues: 0    # Explicitly set to 0 (same as default - no issues allowed)
+  # XSSDomHtml has no cicdmaxissues set, defaults to 0 (no issues allowed)
 ```
 
 This feature allows you to:
 
-- Gradually introduce stricter security requirements by lowering maxissues over time
+- Gradually introduce stricter security requirements by lowering cicdmaxissues over time
 - Prevent technical debt from growing while you address existing issues  
 - Start enforcing security on a codebase with 150 existing issues, then reduce to 100, 50, and eventually 0
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -289,7 +289,7 @@ This allows developers to add a subset of the overall ruleset to ASIST to their 
 
 ## Rule Max Issues
 
-When introducing ASIST to an existing codebase, you may have pre-existing security issues that you want to prevent from increasing while you work on fixing them. The `cicdmaxissues` property in [`ruleoverrides`](#-customizing-standard-rules) allows you to set maximum allowed issue counts for specific rules.
+When introducing ASIST to an existing codebase, you may have pre-existing security issues that you want to prevent from increasing while you work on fixing them. The `cicdmaxissues` property in [`ruleoverrides`](#-customizing-standard-rules) allows you to set maximum allowed issue counts for specific rules for CI/CD mode (with option -j) scanning only.
 
 **By default, rules have a limit of 0 issues.** When a rule exceeds its `cicdmaxissues` threshold, ASIST will exit with an error code (see [Exit Codes](#-exit-codes)). You only need to set `cicdmaxissues` if you want to allow existing issues while preventing them from growing.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,6 @@ Alternatively:
 - To cross-compile: `GOOS=windows GOARCH=amd64 go build -o asist.exe .`
 - To build binaries for the most common platforms, run: `make build-binaries`
 
-
 ## 🕹️ Usage
 
 To see the help, run:
@@ -198,12 +197,12 @@ Configuration files can also be explicitly specified using the `-c` argument (no
 
 Within the config file, you can:
 
-* Enable/disable all the standard rules
-* Override certain properties of standard rules
-* Exclude files or directories for all rules
-* Exclude files or directories for specific rules
-* Add custom regex rules
-* Define rules to be run in CI/CD mode
+- Enable/disable all the standard rules
+- Override certain properties of standard rules
+- Exclude files or directories for all rules
+- Exclude files or directories for specific rules
+- Add custom regex rules
+- Define rules to be run in CI/CD mode
 
 See our [example config file](https://github.com/certinia/asist/blob/main/.asist.example.yaml) for a walkthrough of all config options.
 
@@ -212,6 +211,7 @@ See our [example config file](https://github.com/certinia/asist/blob/main/.asist
 Users can override certain properties of standard rules according to their needs, allowing them to customize the behavior of specific rules by:
 
 - Disabling rules entirely: `enabled`
+- Limiting the number of allowed rule violations: [`maxissues`](#rule-max-issues)
 - Tweaking rule severity: `severity`
 - Tweaking what files should be scanned: `includepattern`
 - Tweaking what files should not be scanned: `excludepattern`
@@ -234,7 +234,6 @@ customregexrules:
 ```
 
 You can test this specific rule like this:
-
 
 ```shell
 asist -c .asist.yaml -r doNotDebug <file>
@@ -283,11 +282,33 @@ In this mode, by default, all enabled runs will be run if `cicdrules` property i
 cicdrules:
   - "XSSLabel"
   - "XSSMergeField"
+  - "XSSDomHtml"
 ```
 
 This allows developers to add a subset of the overall ruleset to ASIST to their CI/CD pipelines, and gradually add more rules to CI/CD as they start clearing out findings for other rules. This prevents any issues for rules defined in `cicdrules` from creeping back into the codebase.
 
-### 📊 Baseline scans
+## Rule Max Issues
+
+When introducing ASIST to an existing codebase, you may have pre-existing security issues that you want to prevent from increasing while you work on fixing them. The `maxissues` property in [`ruleoverrides`](#-customizing-standard-rules) allows you to set maximum allowed issue counts for specific rules.
+
+**By default, rules have a limit of 0 issues.** When a rule exceeds its `maxissues` threshold, ASIST will exit with an error code (see [Exit Codes](#-exit-codes)). You only need to set `maxissues` if you want to allow existing issues while preventing them from growing.
+
+```yaml
+ruleoverrides:
+  XSSLabel:
+    maxissues: 150  # Allow up to 150 XSSTooltip issues (grandfather existing issues)
+  XSSMergeField:
+    maxissues: 0    # Explicitly set to 0 (same as default - no issues allowed)
+  # XSSDomHtml has no maxissues set, defaults to 0 (no issues allowed)
+```
+
+This feature allows you to:
+
+- Gradually introduce stricter security requirements by lowering maxissues over time
+- Prevent technical debt from growing while you address existing issues  
+- Start enforcing security on a codebase with 150 existing issues, then reduce to 100, 50, and eventually 0
+
+## 📊 Baseline scans
 
 This mode is intended for SecOps teams to create benchmarks across multiple projects and measure the adoption of ASIST.
 
@@ -305,32 +326,32 @@ This command will output a JSON like this (when formatted):
 
 ```json
 [
-	{
-		"RepositoryName": "certinia/asist",
-		"RepositoryURL": "git@github.com:certinia/asist.git",
-		"RecordType": "Finding",
-		"Content": {
-			"FindingID": "b17fe249915712219aca7e",
-			"IsCustom": false,
-			"IsFalsePositive": true,
-			"RuleID": "LwcNonStandardPositioning",
-			"Severity": "Medium",
-			"RuleCategory": "Security"
-		}
-	},
-	{
-		"RepositoryName": "certinia/asist",
-		"RepositoryURL": "git@github.com:certinia/asist.git",
-		"RecordType": "Finding",
-		"Content": {
-			"FindingID": "3a2861bee641864816b86d",
-			"IsCustom": false,
-			"IsFalsePositive": true,
-			"RuleID": "LwcNonStandardPositioning",
-			"Severity": "Medium",
-			"RuleCategory": "Security"
-		}
-	}
+ {
+  "RepositoryName": "certinia/asist",
+  "RepositoryURL": "git@github.com:certinia/asist.git",
+  "RecordType": "Finding",
+  "Content": {
+   "FindingID": "b17fe249915712219aca7e",
+   "IsCustom": false,
+   "IsFalsePositive": true,
+   "RuleID": "LwcNonStandardPositioning",
+   "Severity": "Medium",
+   "RuleCategory": "Security"
+  }
+ },
+ {
+  "RepositoryName": "certinia/asist",
+  "RepositoryURL": "git@github.com:certinia/asist.git",
+  "RecordType": "Finding",
+  "Content": {
+   "FindingID": "3a2861bee641864816b86d",
+   "IsCustom": false,
+   "IsFalsePositive": true,
+   "RuleID": "LwcNonStandardPositioning",
+   "Severity": "Medium",
+   "RuleCategory": "Security"
+  }
+ }
 ]
 ```
 
@@ -341,15 +362,14 @@ A few differences can be observed compared to regular scans:
 - Each issue is assigned a `FindingID`, which is effectively a hash that uniquely identifies the finding based on the rule, the finding location, and if it's a false positive or not.
 - A few more properties are added, such as if the rule is custom, or if the finding is marked as false positive or not.
 
-
-### 🫣 .gitignore and .forceignore files
+## 🫣 .gitignore and .forceignore files
 
 By default, ASIST will ignore files and folders defined inside .gitignore and .forceignore. If you don't want ASIST to respect .gitignore and .forceignore, you can use the following properties in the config file:
 
 - **dontgitignore**
 - **dontforceignore**
 
-### ⍈ Exit Codes
+## ⍈ Exit Codes
 
 | Exit code | Exit Reason                                              |
 | --------- | -------------------------------------------------------- |
@@ -405,5 +425,5 @@ This extension is shipped with prebuilt ASIST binaries, but if you need to speci
 
 1. Open the ASIST `Extension settings`
 1. Navigate to the `Workspace` tab
-2. Enable the `Custom Binary Enabled` setting
-3. Provide the path to your ASIST binary in `Custom Binary Path`
+1. Enable the `Custom Binary Enabled` setting
+1. Provide the path to your ASIST binary in `Custom Binary Path`

--- a/integrationtests/integration_test.go
+++ b/integrationtests/integration_test.go
@@ -802,18 +802,18 @@ func TestMaxIssues_WhenConfigParsed_MaxIssuesDeserialized(t *testing.T) {
 
 	exposedMax := parsedConfig.GetRuleMaxIssues("ExposedMessageChannel")
 	if exposedMax != 5 {
-		t.Errorf("Expected ExposedMessageChannel maxissues=5, got %d", exposedMax)
+		t.Errorf("Expected ExposedMessageChannel cicdmaxissues=5, got %d", exposedMax)
 	}
 
 	protectedMax := parsedConfig.GetRuleMaxIssues("ProtectedCustomSetting")
 	if protectedMax != 1 {
-		t.Errorf("Expected ProtectedCustomSetting maxissues=1, got %d", protectedMax)
+		t.Errorf("Expected ProtectedCustomSetting cicdmaxissues=1, got %d", protectedMax)
 	}
 
 	// Rule not in config should default to 0
 	unknownMax := parsedConfig.GetRuleMaxIssues("UnknownRule")
 	if unknownMax != 0 {
-		t.Errorf("Expected UnknownRule maxissues=0, got %d", unknownMax)
+		t.Errorf("Expected UnknownRule cicdmaxissues=0, got %d", unknownMax)
 	}
 }
 

--- a/integrationtests/integration_test.go
+++ b/integrationtests/integration_test.go
@@ -800,18 +800,18 @@ func TestMaxIssues_WhenConfigParsed_MaxIssuesDeserialized(t *testing.T) {
 		t.Fatalf("Failed to parse maxissues config: %v", err)
 	}
 
-	exposedMax := parsedConfig.GetRuleMaxIssues("ExposedMessageChannel")
+	exposedMax := parsedConfig.GetRuleCicdMaxIssues("ExposedMessageChannel")
 	if exposedMax != 5 {
 		t.Errorf("Expected ExposedMessageChannel cicdmaxissues=5, got %d", exposedMax)
 	}
 
-	protectedMax := parsedConfig.GetRuleMaxIssues("ProtectedCustomSetting")
+	protectedMax := parsedConfig.GetRuleCicdMaxIssues("ProtectedCustomSetting")
 	if protectedMax != 1 {
 		t.Errorf("Expected ProtectedCustomSetting cicdmaxissues=1, got %d", protectedMax)
 	}
 
 	// Rule not in config should default to 0
-	unknownMax := parsedConfig.GetRuleMaxIssues("UnknownRule")
+	unknownMax := parsedConfig.GetRuleCicdMaxIssues("UnknownRule")
 	if unknownMax != 0 {
 		t.Errorf("Expected UnknownRule cicdmaxissues=0, got %d", unknownMax)
 	}

--- a/integrationtests/integration_test.go
+++ b/integrationtests/integration_test.go
@@ -1,10 +1,14 @@
 package test
 
 import (
+	"bytes"
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/certinia/asist/config"
+	"github.com/certinia/asist/output"
 	"github.com/certinia/asist/rules/standard/codequality"
 	"github.com/certinia/asist/rules/standard/security"
 	"github.com/certinia/asist/scanner"
@@ -781,5 +785,83 @@ func TestDetectImportJavascriptFromFileRule(t *testing.T) {
 		actualResultJson, _ := json.MarshalIndent(projectOutputToPartial(*actualResult), "", "  ")
 		expectedResultJson, _ := json.MarshalIndent(expectedResult, "", "  ")
 		t.Errorf("%s \nActual: %+v, \n\nExpected: %+v", "Actual and expected results are not Equal.", string(actualResultJson), string(expectedResultJson))
+	}
+}
+
+func TestMaxIssues_WhenConfigParsed_MaxIssuesDeserialized(t *testing.T) {
+	//Given
+	const CONFIG_PATH = "./testData/maxissues_config.yaml"
+
+	//When
+	parsedConfig, err := config.ParseConfig(CONFIG_PATH)
+
+	//Then
+	if err != nil {
+		t.Fatalf("Failed to parse maxissues config: %v", err)
+	}
+
+	exposedMax := parsedConfig.GetRuleMaxIssues("ExposedMessageChannel")
+	if exposedMax != 5 {
+		t.Errorf("Expected ExposedMessageChannel maxissues=5, got %d", exposedMax)
+	}
+
+	protectedMax := parsedConfig.GetRuleMaxIssues("ProtectedCustomSetting")
+	if protectedMax != 1 {
+		t.Errorf("Expected ProtectedCustomSetting maxissues=1, got %d", protectedMax)
+	}
+
+	// Rule not in config should default to 0
+	unknownMax := parsedConfig.GetRuleMaxIssues("UnknownRule")
+	if unknownMax != 0 {
+		t.Errorf("Expected UnknownRule maxissues=0, got %d", unknownMax)
+	}
+}
+
+func TestMaxIssues_WhenWithinThreshold_NoViolation(t *testing.T) {
+	//Given - ExposedMessageChannel has maxissues=5 and produces 1 finding
+	createData("./src", security.ExposedMessageChannelRuleID, "./testData/maxissues_config.yaml")
+
+	//When
+	actualResult, _ := scanner.RunRulesOnFiles(filePaths, ruleInstances)
+	actualResult.Count = len(actualResult.Results)
+
+	//Then - should have 1 finding which is within threshold of 5
+	if actualResult.Count != 1 {
+		t.Fatalf("Expected 1 ExposedMessageChannel finding, got %d", actualResult.Count)
+	}
+
+	var buf bytes.Buffer
+	hasViolation := output.CheckThresholdViolations(&buf, actualResult, configFile)
+
+	if hasViolation {
+		t.Errorf("Expected no threshold violation for ExposedMessageChannel (1 finding, max 5), output: %s", buf.String())
+	}
+}
+
+func TestMaxIssues_WhenExceedsThreshold_HasViolation(t *testing.T) {
+	//Given - ProtectedCustomSetting has maxissues=1 and produces 2 findings
+	createData("./src", security.ProtectedCustomSettingRuleID, "./testData/maxissues_config.yaml")
+
+	//When
+	actualResult, _ := scanner.RunRulesOnFiles(filePaths, ruleInstances)
+	actualResult.Count = len(actualResult.Results)
+
+	//Then - should have 2 findings which exceeds threshold of 1
+	if actualResult.Count != 2 {
+		t.Fatalf("Expected 2 ProtectedCustomSetting findings, got %d", actualResult.Count)
+	}
+
+	var buf bytes.Buffer
+	hasViolation := output.CheckThresholdViolations(&buf, actualResult, configFile)
+
+	if !hasViolation {
+		t.Errorf("Expected threshold violation for ProtectedCustomSetting (2 findings, max 1)")
+	}
+	violationOutput := buf.String()
+	if !strings.Contains(violationOutput, "ProtectedCustomSetting") {
+		t.Errorf("Expected ProtectedCustomSetting in violation output, got: %s", violationOutput)
+	}
+	if !strings.Contains(violationOutput, "2 issues (max allowed: 1)") {
+		t.Errorf("Expected '2 issues (max allowed: 1)' in output, got: %s", violationOutput)
 	}
 }

--- a/integrationtests/testData/maxissues_config.yaml
+++ b/integrationtests/testData/maxissues_config.yaml
@@ -6,7 +6,7 @@ dontforceignore: true
 ruleoverrides:
   ExposedMessageChannel:
     enabled: true
-    maxissues: 5
+    cicdmaxissues: 5
   ProtectedCustomSetting:
     enabled: true
-    maxissues: 1
+    cicdmaxissues: 1

--- a/integrationtests/testData/maxissues_config.yaml
+++ b/integrationtests/testData/maxissues_config.yaml
@@ -1,0 +1,12 @@
+enableallstandardrules: true
+
+dontgitignore: true
+dontforceignore: true
+
+ruleoverrides:
+  ExposedMessageChannel:
+    enabled: true
+    maxissues: 5
+  ProtectedCustomSetting:
+    enabled: true
+    maxissues: 1

--- a/message/messages.go
+++ b/message/messages.go
@@ -62,3 +62,15 @@ func GetFileUnmarshalingError(err error) string {
 func GetMarshalIndentError(err error) string {
 	return fmt.Sprintf("%v", err)
 }
+
+func GetThresholdViolationHeader() string {
+	return "Threshold violations:"
+}
+
+func GetThresholdViolation(ruleId string, count int, max int) string {
+	return fmt.Sprintf("  Rule %s has %d issues (max allowed: %d)", ruleId, count, max)
+}
+
+func GetThresholdViolationSummary(count int) string {
+	return fmt.Sprintf("%d rule(s) exceeded their maxissues threshold.", count)
+}

--- a/message/messages.go
+++ b/message/messages.go
@@ -72,5 +72,5 @@ func GetThresholdViolation(ruleId string, count int, max int) string {
 }
 
 func GetThresholdViolationSummary(count int) string {
-	return fmt.Sprintf("%d rule(s) exceeded their maxissues threshold.", count)
+	return fmt.Sprintf("%d rule(s) exceeded their cicdmaxissues threshold.", count)
 }

--- a/output/output.go
+++ b/output/output.go
@@ -43,8 +43,8 @@ func ListRules(ruleInstances []*rules.Rule) {
 }
 
 /**
- * CheckThresholdViolations checks if any rule exceeds its configured maxissues.
- * Default maxissues is 0 (no issues allowed).
+ * CheckThresholdViolations checks if any rule exceeds its configured cicdmaxissues.
+ * Default cicdmaxissues is 0 (no issues allowed).
  * Returns true if any threshold is violated, false otherwise.
  */
 func CheckThresholdViolations(w io.Writer, finalResult *finding.Output, configFile *config.Config) bool {

--- a/output/output.go
+++ b/output/output.go
@@ -41,6 +41,39 @@ func ListRules(ruleInstances []*rules.Rule) {
 }
 
 /**
+ * Checks if any rule exceeds its configured maxissues.
+ * Default maxissues is 0 (no issues allowed) if not explicitly set.
+ * Returns true if any threshold is violated, false otherwise.
+ */
+func checkThresholdViolations(finalResult *finding.Output, configFile *config.Config) bool {
+	findingsPerRule := make(map[rules.RuleID]int)
+
+	for _, finding := range finalResult.Results {
+		findingsPerRule[finding.ID]++
+	}
+
+	// Check each rule that has findings
+	hasViolation := false
+
+	for ruleId, count := range findingsPerRule {
+		maxIssuesAllowed := configFile.GetRuleMaxIssues(ruleId)
+
+		if count > maxIssuesAllowed {
+			fmt.Fprintf(
+				os.Stderr,
+				"Threshold violation: Rule %s has %d issues (max allowed: %d)\n",
+				ruleId,
+				count,
+				maxIssuesAllowed,
+			)
+			hasViolation = true
+		}
+	}
+
+	return hasViolation
+}
+
+/**
  * DisplayOutput - method used to display the output of scans by type
  */
 func DisplayOutput(finalResult *finding.Output, scanTime *ScanTime) {
@@ -56,8 +89,9 @@ func DisplayOutput(finalResult *finding.Output, scanTime *ScanTime) {
 		finalResult.Count = len(finalResult.Results)
 		displayOutput(finalResult)
 
-		//Returns exit 1 in case of the CICD rules defined in the configFile
-		if finalResult.Count > 0 && options.IsCICDScan() {
+		configFile := config.GetConfigInstance()
+		
+		if options.IsCICDScan() && checkThresholdViolations(finalResult, configFile) {
 			os.Exit(int(errorhandler.ExitCodeOccurrence))
 		}
 	}

--- a/output/output.go
+++ b/output/output.go
@@ -68,7 +68,7 @@ func CheckThresholdViolations(w io.Writer, finalResult *finding.Output, configFi
 
 	for _, ruleId := range sortedRuleIds {
 		count := findingsPerRule[ruleId]
-		maxIssuesAllowed := configFile.GetRuleMaxIssues(ruleId)
+		maxIssuesAllowed := configFile.GetRuleCicdMaxIssues(ruleId)
 
 		if count > maxIssuesAllowed {
 			if violationCount == 0 {

--- a/output/output.go
+++ b/output/output.go
@@ -3,9 +3,11 @@ package output
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"runtime/debug"
+	"sort"
 
 	"time"
 
@@ -41,36 +43,47 @@ func ListRules(ruleInstances []*rules.Rule) {
 }
 
 /**
- * Checks if any rule exceeds its configured maxissues.
- * Default maxissues is 0 (no issues allowed) if not explicitly set.
+ * CheckThresholdViolations checks if any rule exceeds its configured maxissues.
+ * Default maxissues is 0 (no issues allowed).
  * Returns true if any threshold is violated, false otherwise.
  */
-func checkThresholdViolations(finalResult *finding.Output, configFile *config.Config) bool {
+func CheckThresholdViolations(w io.Writer, finalResult *finding.Output, configFile *config.Config) bool {
 	findingsPerRule := make(map[rules.RuleID]int)
 
 	for _, finding := range finalResult.Results {
 		findingsPerRule[finding.ID]++
 	}
 
-	// Check each rule that has findings
-	hasViolation := false
+	// Sort rule IDs for deterministic output
+	sortedRuleIds := make([]rules.RuleID, 0, len(findingsPerRule))
+	for ruleId := range findingsPerRule {
+		sortedRuleIds = append(sortedRuleIds, ruleId)
+	}
+	sort.Slice(sortedRuleIds, func(i, j int) bool {
+		return string(sortedRuleIds[i]) < string(sortedRuleIds[j])
+	})
 
-	for ruleId, count := range findingsPerRule {
+	// Check each rule that has findings
+	violationCount := 0
+
+	for _, ruleId := range sortedRuleIds {
+		count := findingsPerRule[ruleId]
 		maxIssuesAllowed := configFile.GetRuleMaxIssues(ruleId)
 
 		if count > maxIssuesAllowed {
-			fmt.Fprintf(
-				os.Stderr,
-				"Threshold violation: Rule %s has %d issues (max allowed: %d)\n",
-				ruleId,
-				count,
-				maxIssuesAllowed,
-			)
-			hasViolation = true
+			if violationCount == 0 {
+				fmt.Fprintf(w, "\n%s\n", message.GetThresholdViolationHeader())
+			}
+			fmt.Fprintf(w, "%s\n", message.GetThresholdViolation(string(ruleId), count, maxIssuesAllowed))
+			violationCount++
 		}
 	}
 
-	return hasViolation
+	if violationCount > 0 {
+		fmt.Fprintf(w, "\n%s\n", message.GetThresholdViolationSummary(violationCount))
+	}
+
+	return violationCount > 0
 }
 
 /**
@@ -90,8 +103,8 @@ func DisplayOutput(finalResult *finding.Output, scanTime *ScanTime) {
 		displayOutput(finalResult)
 
 		configFile := config.GetConfigInstance()
-		
-		if options.IsCICDScan() && checkThresholdViolations(finalResult, configFile) {
+
+		if options.IsCICDScan() && CheckThresholdViolations(os.Stderr, finalResult, configFile) {
 			os.Exit(int(errorhandler.ExitCodeOccurrence))
 		}
 	}

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -291,7 +291,7 @@ func TestCheckThresholdViolations_WhenMultipleRules_ReportsAllViolations(t *test
 	}
 }
 
-func TestCheckThresholdViolations_WhenMaxIssuesNotSet_DefaultsToZero(t *testing.T) {
+func TestCheckThresholdViolations_WhenCicdMaxIssuesNotSet_DefaultsToZero(t *testing.T) {
 	//Given
 	finalResult := &finding.Output{
 		Results: []finding.Finding{
@@ -308,7 +308,7 @@ func TestCheckThresholdViolations_WhenMaxIssuesNotSet_DefaultsToZero(t *testing.
 
 	//Then
 	if !result {
-		t.Errorf("Expected violation when maxissues defaults to 0 and rule has 1 finding")
+		t.Errorf("Expected violation when cicdmaxissues defaults to 0 and rule has 1 finding")
 	}
 	output := buf.String()
 	if !strings.Contains(output, "Rule SomeRule has 1 issues (max allowed: 0)") {

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -1,7 +1,9 @@
 package output
 
 import (
+	"bytes"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/certinia/asist/config"
@@ -111,5 +113,254 @@ func TestCreateBaselineOutput_WhenInputUrlNil_ReturnsOutputWithoutRepoNameAndUrl
 	//Then
 	if !reflect.DeepEqual(actualBaselineOutput, expectedBaselineOutput) {
 		t.Errorf("%s Actual: %+v, Expected: %+v", "Baseline output is mismatched!", actualBaselineOutput, expectedBaselineOutput)
+	}
+}
+
+// Helper to create an int pointer
+func intPtr(v int) *int {
+	return &v
+}
+
+func TestCheckThresholdViolations_WhenNoFindings_ReturnsFalse(t *testing.T) {
+	//Given
+	finalResult := &finding.Output{
+		Results: []finding.Finding{},
+	}
+	configFile := &config.Config{
+		RuleOverrides: map[string]rules.RuleMetadataOverride{},
+	}
+	var buf bytes.Buffer
+
+	//When
+	result := CheckThresholdViolations(&buf, finalResult, configFile)
+
+	//Then
+	if result {
+		t.Errorf("Expected no violation when there are no findings")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("Expected no output when there are no findings, got: %s", buf.String())
+	}
+}
+
+func TestCheckThresholdViolations_WhenWithinThreshold_ReturnsFalse(t *testing.T) {
+	//Given
+	finalResult := &finding.Output{
+		Results: []finding.Finding{
+			{ID: "XSSTooltip"},
+			{ID: "XSSTooltip"},
+			{ID: "XSSTooltip"},
+		},
+	}
+	configFile := &config.Config{
+		RuleOverrides: map[string]rules.RuleMetadataOverride{
+			"XSSTooltip": {
+				MaxIssues: intPtr(10),
+			},
+		},
+	}
+	var buf bytes.Buffer
+
+	//When
+	result := CheckThresholdViolations(&buf, finalResult, configFile)
+
+	//Then
+	if result {
+		t.Errorf("Expected no violation when findings (3) are within threshold (10)")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("Expected no output when within threshold, got: %s", buf.String())
+	}
+}
+
+func TestCheckThresholdViolations_WhenExceedsThreshold_ReturnsTrue(t *testing.T) {
+	//Given
+	finalResult := &finding.Output{
+		Results: []finding.Finding{
+			{ID: "XSSTooltip"},
+			{ID: "XSSTooltip"},
+			{ID: "XSSTooltip"},
+			{ID: "XSSTooltip"},
+			{ID: "XSSTooltip"},
+		},
+	}
+	configFile := &config.Config{
+		RuleOverrides: map[string]rules.RuleMetadataOverride{
+			"XSSTooltip": {
+				MaxIssues: intPtr(2),
+			},
+		},
+	}
+	var buf bytes.Buffer
+
+	//When
+	result := CheckThresholdViolations(&buf, finalResult, configFile)
+
+	//Then
+	if !result {
+		t.Errorf("Expected violation when findings (5) exceed threshold (2)")
+	}
+	output := buf.String()
+	if !strings.Contains(output, "Threshold violations:") {
+		t.Errorf("Expected header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "Rule XSSTooltip has 5 issues (max allowed: 2)") {
+		t.Errorf("Expected violation detail in output, got: %s", output)
+	}
+	if !strings.Contains(output, "1 rule(s) exceeded their maxissues threshold.") {
+		t.Errorf("Expected summary in output, got: %s", output)
+	}
+}
+
+func TestCheckThresholdViolations_WhenExactlyAtThreshold_ReturnsFalse(t *testing.T) {
+	//Given
+	finalResult := &finding.Output{
+		Results: []finding.Finding{
+			{ID: "XSSTooltip"},
+			{ID: "XSSTooltip"},
+			{ID: "XSSTooltip"},
+			{ID: "XSSTooltip"},
+			{ID: "XSSTooltip"},
+		},
+	}
+	configFile := &config.Config{
+		RuleOverrides: map[string]rules.RuleMetadataOverride{
+			"XSSTooltip": {
+				MaxIssues: intPtr(5),
+			},
+		},
+	}
+	var buf bytes.Buffer
+
+	//When
+	result := CheckThresholdViolations(&buf, finalResult, configFile)
+
+	//Then
+	if result {
+		t.Errorf("Expected no violation when findings (5) are exactly at threshold (5)")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("Expected no output when at threshold, got: %s", buf.String())
+	}
+}
+
+func TestCheckThresholdViolations_WhenMultipleRules_ReportsAllViolations(t *testing.T) {
+	//Given
+	finalResult := &finding.Output{
+		Results: []finding.Finding{
+			{ID: "RuleA"},
+			{ID: "RuleA"},
+			{ID: "RuleA"},
+			{ID: "RuleB"},
+			{ID: "RuleB"},
+			{ID: "RuleC"},
+		},
+	}
+	configFile := &config.Config{
+		RuleOverrides: map[string]rules.RuleMetadataOverride{
+			"RuleA": {
+				MaxIssues: intPtr(1), // 3 > 1, violation
+			},
+			"RuleB": {
+				MaxIssues: intPtr(5), // 2 <= 5, no violation
+			},
+			// RuleC has no override, defaults to 0, 1 > 0, violation
+		},
+	}
+	var buf bytes.Buffer
+
+	//When
+	result := CheckThresholdViolations(&buf, finalResult, configFile)
+
+	//Then
+	if !result {
+		t.Errorf("Expected violations for RuleA and RuleC")
+	}
+	output := buf.String()
+	if !strings.Contains(output, "Rule RuleA has 3 issues (max allowed: 1)") {
+		t.Errorf("Expected RuleA violation in output, got: %s", output)
+	}
+	if !strings.Contains(output, "Rule RuleC has 1 issues (max allowed: 0)") {
+		t.Errorf("Expected RuleC violation in output, got: %s", output)
+	}
+	if strings.Contains(output, "RuleB") {
+		t.Errorf("RuleB should not appear in violations, got: %s", output)
+	}
+	if !strings.Contains(output, "2 rule(s) exceeded their maxissues threshold.") {
+		t.Errorf("Expected summary with 2 violations, got: %s", output)
+	}
+}
+
+func TestCheckThresholdViolations_WhenMaxIssuesNotSet_DefaultsToZero(t *testing.T) {
+	//Given
+	finalResult := &finding.Output{
+		Results: []finding.Finding{
+			{ID: "SomeRule"},
+		},
+	}
+	configFile := &config.Config{
+		RuleOverrides: map[string]rules.RuleMetadataOverride{},
+	}
+	var buf bytes.Buffer
+
+	//When
+	result := CheckThresholdViolations(&buf, finalResult, configFile)
+
+	//Then
+	if !result {
+		t.Errorf("Expected violation when maxissues defaults to 0 and rule has 1 finding")
+	}
+	output := buf.String()
+	if !strings.Contains(output, "Rule SomeRule has 1 issues (max allowed: 0)") {
+		t.Errorf("Expected default threshold violation, got: %s", output)
+	}
+}
+
+func TestCheckThresholdViolations_WhenConfigNil_DefaultsToZero(t *testing.T) {
+	//Given
+	finalResult := &finding.Output{
+		Results: []finding.Finding{
+			{ID: "SomeRule"},
+		},
+	}
+	var configFile *config.Config
+	var buf bytes.Buffer
+
+	//When
+	result := CheckThresholdViolations(&buf, finalResult, configFile)
+
+	//Then
+	if !result {
+		t.Errorf("Expected violation when config is nil and rule has findings")
+	}
+}
+
+func TestCheckThresholdViolations_OutputIsSortedByRuleID(t *testing.T) {
+	//Given
+	finalResult := &finding.Output{
+		Results: []finding.Finding{
+			{ID: "ZRule"},
+			{ID: "ARule"},
+			{ID: "MRule"},
+		},
+	}
+	configFile := &config.Config{
+		RuleOverrides: map[string]rules.RuleMetadataOverride{},
+	}
+	var buf bytes.Buffer
+
+	//When
+	CheckThresholdViolations(&buf, finalResult, configFile)
+
+	//Then
+	output := buf.String()
+	aIdx := strings.Index(output, "ARule")
+	mIdx := strings.Index(output, "MRule")
+	zIdx := strings.Index(output, "ZRule")
+	if aIdx == -1 || mIdx == -1 || zIdx == -1 {
+		t.Fatalf("Expected all rules in output, got: %s", output)
+	}
+	if !(aIdx < mIdx && mIdx < zIdx) {
+		t.Errorf("Expected rules sorted alphabetically (A < M < Z), got: %s", output)
 	}
 }

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -155,7 +155,7 @@ func TestCheckThresholdViolations_WhenWithinThreshold_ReturnsFalse(t *testing.T)
 	configFile := &config.Config{
 		RuleOverrides: map[string]rules.RuleMetadataOverride{
 			"XSSTooltip": {
-				MaxIssues: intPtr(10),
+				CicdMaxIssues: intPtr(10),
 			},
 		},
 	}
@@ -187,7 +187,7 @@ func TestCheckThresholdViolations_WhenExceedsThreshold_ReturnsTrue(t *testing.T)
 	configFile := &config.Config{
 		RuleOverrides: map[string]rules.RuleMetadataOverride{
 			"XSSTooltip": {
-				MaxIssues: intPtr(2),
+				CicdMaxIssues: intPtr(2),
 			},
 		},
 	}
@@ -207,7 +207,7 @@ func TestCheckThresholdViolations_WhenExceedsThreshold_ReturnsTrue(t *testing.T)
 	if !strings.Contains(output, "Rule XSSTooltip has 5 issues (max allowed: 2)") {
 		t.Errorf("Expected violation detail in output, got: %s", output)
 	}
-	if !strings.Contains(output, "1 rule(s) exceeded their maxissues threshold.") {
+	if !strings.Contains(output, "1 rule(s) exceeded their cicdmaxissues threshold.") {
 		t.Errorf("Expected summary in output, got: %s", output)
 	}
 }
@@ -226,7 +226,7 @@ func TestCheckThresholdViolations_WhenExactlyAtThreshold_ReturnsFalse(t *testing
 	configFile := &config.Config{
 		RuleOverrides: map[string]rules.RuleMetadataOverride{
 			"XSSTooltip": {
-				MaxIssues: intPtr(5),
+				CicdMaxIssues: intPtr(5),
 			},
 		},
 	}
@@ -259,10 +259,10 @@ func TestCheckThresholdViolations_WhenMultipleRules_ReportsAllViolations(t *test
 	configFile := &config.Config{
 		RuleOverrides: map[string]rules.RuleMetadataOverride{
 			"RuleA": {
-				MaxIssues: intPtr(1), // 3 > 1, violation
+				CicdMaxIssues: intPtr(1), // 3 > 1, violation
 			},
 			"RuleB": {
-				MaxIssues: intPtr(5), // 2 <= 5, no violation
+				CicdMaxIssues: intPtr(5), // 2 <= 5, no violation
 			},
 			// RuleC has no override, defaults to 0, 1 > 0, violation
 		},
@@ -286,7 +286,7 @@ func TestCheckThresholdViolations_WhenMultipleRules_ReportsAllViolations(t *test
 	if strings.Contains(output, "RuleB") {
 		t.Errorf("RuleB should not appear in violations, got: %s", output)
 	}
-	if !strings.Contains(output, "2 rule(s) exceeded their maxissues threshold.") {
+	if !strings.Contains(output, "2 rule(s) exceeded their cicdmaxissues threshold.") {
 		t.Errorf("Expected summary with 2 violations, got: %s", output)
 	}
 }

--- a/rules/Rule.go
+++ b/rules/Rule.go
@@ -61,6 +61,7 @@ type RuleMetadataOverride struct {
 	ExcludePattern string
 	IncludePattern string
 	Enabled        *bool
+	MaxIssues      *int
 }
 
 /**

--- a/rules/Rule.go
+++ b/rules/Rule.go
@@ -46,6 +46,8 @@ type RuleMetadata struct {
 	RuleCategory RuleCategory
 	//Qualifier - don't search the file if the file does not contain the qualifier
 	Qualifier string
+	// CicdMaxIssues is the maximum number of issues allowed in CI/CD mode (0 = none allowed)
+	CicdMaxIssues int
 }
 
 type Occurrence struct {
@@ -61,7 +63,7 @@ type RuleMetadataOverride struct {
 	ExcludePattern string
 	IncludePattern string
 	Enabled        *bool
-	MaxIssues      *int
+	CicdMaxIssues  *int
 }
 
 /**
@@ -76,6 +78,9 @@ func (md *RuleMetadata) Override(overrideRule RuleMetadataOverride, isBaselineSc
 	}
 	if overrideRule.ExcludePattern != "" {
 		md.ExcludePattern = overrideRule.ExcludePattern
+	}
+	if overrideRule.CicdMaxIssues != nil {
+		md.CicdMaxIssues = *overrideRule.CicdMaxIssues
 	}
 }
 

--- a/rules/Rule_test.go
+++ b/rules/Rule_test.go
@@ -46,6 +46,45 @@ func TestOverride(t *testing.T) {
 	}
 }
 
+func TestOverride_WhenCicdMaxIssuesSet_PopulatesRuleMetadata(t *testing.T) {
+	// Given
+	standardRuleMetadata := RuleMetadata{
+		ID:       "SampleRule1",
+		Severity: SeverityHigh,
+	}
+	maxIssues := 42
+	override := RuleMetadataOverride{
+		CicdMaxIssues: &maxIssues,
+	}
+
+	// When
+	standardRuleMetadata.Override(override, false)
+
+	// Then
+	if standardRuleMetadata.CicdMaxIssues != 42 {
+		t.Errorf("Expected CicdMaxIssues to be 42, got %d", standardRuleMetadata.CicdMaxIssues)
+	}
+}
+
+func TestOverride_WhenCicdMaxIssuesNotSet_DefaultsToZero(t *testing.T) {
+	// Given
+	standardRuleMetadata := RuleMetadata{
+		ID:       "SampleRule1",
+		Severity: SeverityHigh,
+	}
+	override := RuleMetadataOverride{
+		Severity: "Critical",
+	}
+
+	// When
+	standardRuleMetadata.Override(override, false)
+
+	// Then
+	if standardRuleMetadata.CicdMaxIssues != 0 {
+		t.Errorf("Expected CicdMaxIssues to default to 0, got %d", standardRuleMetadata.CicdMaxIssues)
+	}
+}
+
 func TestCreateHashableString(t *testing.T) {
 	// Given
 	occurrence := Occurrence{

--- a/rules/customrule/CustomRule.go
+++ b/rules/customrule/CustomRule.go
@@ -15,6 +15,12 @@ type CustomRule struct {
  * NewCustomRule - method used create a custom rule
  */
 func NewCustomRule(customRule config.CustomRegexRule, customRuleID rules.RuleID) *CustomRule {
+	cicdMaxIssues := 0
+
+	if customRule.CicdMaxIssues != nil {
+		cicdMaxIssues = *customRule.CicdMaxIssues
+	}
+
 	return &CustomRule{
 		metadata: rules.RuleMetadata{
 			ID:             customRuleID,
@@ -25,6 +31,7 @@ func NewCustomRule(customRule config.CustomRegexRule, customRuleID rules.RuleID)
 			IncludePattern: customRule.IncludePattern,
 			ExcludePattern: customRule.ExcludePattern,
 			Pattern:        customRule.Pattern,
+			CicdMaxIssues:  cicdMaxIssues,
 		},
 	}
 }

--- a/rules/customrule/CustomRule_test.go
+++ b/rules/customrule/CustomRule_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestNewCustomRule(t *testing.T) {
 	// Given
+	MAX_5 := 5
 	customRule := config.CustomRegexRule{
 		Name:           "CustomRule1",
 		Description:    "This is sample description for the custom rule",
@@ -19,6 +20,7 @@ func TestNewCustomRule(t *testing.T) {
 		IncludePattern: ".*.cls",
 		ExcludePattern: ".*test.cls$",
 		Pattern:        "pattern",
+		CicdMaxIssues:  &MAX_5,
 	}
 
 	customRuleInstance := rules.RuleMetadata{
@@ -30,6 +32,7 @@ func TestNewCustomRule(t *testing.T) {
 		IncludePattern: customRule.IncludePattern,
 		ExcludePattern: customRule.ExcludePattern,
 		Pattern:        customRule.Pattern,
+		CicdMaxIssues:  5,
 	}
 
 	expectedcustomRuleInstance := CustomRule{
@@ -42,6 +45,23 @@ func TestNewCustomRule(t *testing.T) {
 	// Then
 	if !reflect.DeepEqual(actualCustomRuleInstance, expectedcustomRuleInstance) {
 		t.Errorf("%s Actual: %+v, Expected: %+v", "CustomRule is mismatched!", actualCustomRuleInstance, expectedcustomRuleInstance)
+	}
+}
+
+func TestNewCustomRule_WhenCicdMaxIssuesNotSet_DefaultsToZero(t *testing.T) {
+	// Given
+	customRule := config.CustomRegexRule{
+		Name:     "CustomRule1",
+		Severity: "High",
+		Pattern:  "pattern",
+	}
+
+	// When
+	actualCustomRuleInstance := NewCustomRule(customRule, "custom_rule_1")
+
+	// Then
+	if actualCustomRuleInstance.metadata.CicdMaxIssues != 0 {
+		t.Errorf("Expected CicdMaxIssues to default to 0, got %d", actualCustomRuleInstance.metadata.CicdMaxIssues)
 	}
 }
 


### PR DESCRIPTION
Currently, asist fails if any issues are detected (equivalent to a hard cap of 0). This change allows users to define a custom limit per rule.

💡 Why is this needed?
On large or legacy repositories, "perfect" compliance is often impossible to achieve overnight. By allowing a maxIssues threshold, teams can:

Grandfather in existing issues: Set the cap to the current issue count to prevent new regressions.

Incremental Improvement: Gradually lower the cap over time as technical debt is cleared.

CI Adoption: Enable the analyzer in CI/CD pipelines without immediately breaking the build for existing debt.

🛠 Proposed Changes
Added a maxIssues configuration option per rule.

Default Behavior: If no cap is defined, it defaults to 0, maintaining the current strict enforcement behavior.

Logic: The build fails only if actualIssues > maxIssues.

**Why only CI/CD?**: It only exits with error codes if it's in CI/CD mode, otherwise it simply prints out the issues.
Perhaps we would also like to Print a warning outside of CI/CD? Would that mess with baseline or anything though?

🧪 WIP Notes (Seeking Early Input)
I am raising this as a Draft PR to get feedback on the implementation logic before I finalize the test suite. Specifically:

Does the flag naming (maxIssues) align with the project's naming conventions?
Here's some other options I considered.
- issuethreshold
- maxallowedissues
- cicdmaxissues
- failon

Are there any edge cases in the threshold logic I should account for before I write the unit tests?

I added a printing log in CI/CD mode, is this a **breaking change** as it now no longer ONLY prints the issues?