### PR TITLE
fix(output): improve violation comprehension in CI/CD mode

### DIFF
--- a/finding/Finding_test.go
+++ b/finding/Finding_test.go
@@ -9,8 +9,8 @@ import (
 func TestCreateFindingID(t *testing.T) {
 	// Given
 	occurrence := rules.Occurrence{
-		FileName:        "TestMessageChannel.messageChannel-meta.xml",
-		LineContent:     "	<isExposed>true</isExposed>",
+		FileName: "TestMessageChannel.messageChannel-meta.xml",
+		LineContent: "	<isExposed>true</isExposed>",
 		LineNumber:      10,
 		ColumnRange:     []int{1, 28},
 		IsFalsePositive: false,

--- a/message/messages.go
+++ b/message/messages.go
@@ -74,3 +74,7 @@ func GetThresholdViolation(ruleId string, count int, max int) string {
 func GetThresholdViolationSummary(count int) string {
 	return fmt.Sprintf("%d rule(s) exceeded their cicdmaxissues threshold.", count)
 }
+
+func GetNoThresholdViolationSummary() string {
+	return "No rules exceeded their cicdmaxissues threshold."
+}

--- a/output/output.go
+++ b/output/output.go
@@ -43,47 +43,74 @@ func ListRules(ruleInstances []*rules.Rule) {
 }
 
 /**
+ * countFindingsPerRule counts the findings of each rule.
+ */
+func countFindingsPerRule(finalResult *finding.Output) map[rules.RuleID]int {
+	findingsPerRule := make(map[rules.RuleID]int)
+	for _, finding := range finalResult.Results {
+		findingsPerRule[finding.ID]++
+	}
+	return findingsPerRule
+}
+
+/**
+ * getViolatedRuleIds returns the IDs of rules whose finding count exceeds their
+ * configured cicdmaxissues, sorted for deterministic output.
+ * Default cicdmaxissues is 0 (no issues allowed).
+ */
+func getViolatedRuleIds(findingsPerRule map[rules.RuleID]int, configFile *config.Config) []rules.RuleID {
+	violatedRuleIds := []rules.RuleID{}
+	for ruleId, count := range findingsPerRule {
+		if count > configFile.GetRuleCicdMaxIssues(ruleId) {
+			violatedRuleIds = append(violatedRuleIds, ruleId)
+		}
+	}
+	sort.Slice(violatedRuleIds, func(i, j int) bool {
+		return string(violatedRuleIds[i]) < string(violatedRuleIds[j])
+	})
+	return violatedRuleIds
+}
+
+/**
+ * filterFindingsByRules removes findings that do not belong to the given rules
+ * and updates the result count accordingly.
+ */
+func filterFindingsByRules(finalResult *finding.Output, ruleIds []rules.RuleID) {
+	includedRuleIds := make(map[rules.RuleID]bool, len(ruleIds))
+	for _, ruleId := range ruleIds {
+		includedRuleIds[ruleId] = true
+	}
+
+	filteredResults := []finding.Finding{}
+	for _, finding := range finalResult.Results {
+		if includedRuleIds[finding.ID] {
+			filteredResults = append(filteredResults, finding)
+		}
+	}
+	finalResult.Results = filteredResults
+	finalResult.Count = len(filteredResults)
+}
+
+/**
  * CheckThresholdViolations checks if any rule exceeds its configured cicdmaxissues.
  * Default cicdmaxissues is 0 (no issues allowed).
  * Returns true if any threshold is violated, false otherwise.
  */
 func CheckThresholdViolations(w io.Writer, finalResult *finding.Output, configFile *config.Config) bool {
-	findingsPerRule := make(map[rules.RuleID]int)
+	findingsPerRule := countFindingsPerRule(finalResult)
+	violatedRuleIds := getViolatedRuleIds(findingsPerRule, configFile)
 
-	for _, finding := range finalResult.Results {
-		findingsPerRule[finding.ID]++
+	if len(violatedRuleIds) == 0 {
+		return false
 	}
 
-	// Sort rule IDs for deterministic output
-	sortedRuleIds := make([]rules.RuleID, 0, len(findingsPerRule))
-	for ruleId := range findingsPerRule {
-		sortedRuleIds = append(sortedRuleIds, ruleId)
+	fmt.Fprintf(w, "\n%s\n", message.GetThresholdViolationHeader())
+	for _, ruleId := range violatedRuleIds {
+		fmt.Fprintf(w, "%s\n", message.GetThresholdViolation(string(ruleId), findingsPerRule[ruleId], configFile.GetRuleCicdMaxIssues(ruleId)))
 	}
-	sort.Slice(sortedRuleIds, func(i, j int) bool {
-		return string(sortedRuleIds[i]) < string(sortedRuleIds[j])
-	})
+	fmt.Fprintf(w, "\n%s\n", message.GetThresholdViolationSummary(len(violatedRuleIds)))
 
-	// Check each rule that has findings
-	violationCount := 0
-
-	for _, ruleId := range sortedRuleIds {
-		count := findingsPerRule[ruleId]
-		maxIssuesAllowed := configFile.GetRuleCicdMaxIssues(ruleId)
-
-		if count > maxIssuesAllowed {
-			if violationCount == 0 {
-				fmt.Fprintf(w, "\n%s\n", message.GetThresholdViolationHeader())
-			}
-			fmt.Fprintf(w, "%s\n", message.GetThresholdViolation(string(ruleId), count, maxIssuesAllowed))
-			violationCount++
-		}
-	}
-
-	if violationCount > 0 {
-		fmt.Fprintf(w, "\n%s\n", message.GetThresholdViolationSummary(violationCount))
-	}
-
-	return violationCount > 0
+	return true
 }
 
 /**
@@ -100,13 +127,24 @@ func DisplayOutput(finalResult *finding.Output, scanTime *ScanTime) {
 		finalResult.ScanStartedTime = scanTime.StartedTime
 		finalResult.ScanEndingTime = scanTime.EndingTime
 		finalResult.Count = len(finalResult.Results)
-		displayOutput(finalResult)
 
-		configFile := config.GetConfigInstance()
+		if options.IsCICDScan() {
+			configFile := config.GetConfigInstance()
+			violatedRuleIds := getViolatedRuleIds(countFindingsPerRule(finalResult), configFile)
 
-		if options.IsCICDScan() && CheckThresholdViolations(os.Stderr, finalResult, configFile) {
-			os.Exit(int(errorhandler.ExitCodeOccurrence))
+			if len(violatedRuleIds) > 0 {
+				filterFindingsByRules(finalResult, violatedRuleIds)
+				displayOutput(finalResult)
+				CheckThresholdViolations(os.Stdout, finalResult, configFile)
+				os.Exit(int(errorhandler.ExitCodeOccurrence))
+			}
+
+			displayOutput(finalResult)
+			fmt.Printf("\n%s\n", message.GetNoThresholdViolationSummary())
+			return
 		}
+
+		displayOutput(finalResult)
 	}
 }
 

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -335,6 +335,88 @@ func TestCheckThresholdViolations_WhenConfigNil_DefaultsToZero(t *testing.T) {
 	}
 }
 
+func TestGetViolatedRuleIds_ReturnsOnlyBreachedRulesSorted(t *testing.T) {
+	//Given
+	finalResult := &finding.Output{
+		Results: []finding.Finding{
+			{ID: "ZRule"},
+			{ID: "ZRule"},
+			{ID: "ARule"},
+			{ID: "ARule"},
+			{ID: "MRule"},
+		},
+	}
+	configFile := &config.Config{
+		RuleOverrides: map[string]rules.RuleMetadataOverride{
+			"ZRule": {CicdMaxIssues: intPtr(1)}, // 2 > 1, violation
+			"ARule": {CicdMaxIssues: intPtr(1)}, // 2 > 1, violation
+			"MRule": {CicdMaxIssues: intPtr(5)}, // 1 <= 5, no violation
+		},
+	}
+
+	//When
+	violatedRuleIds := getViolatedRuleIds(countFindingsPerRule(finalResult), configFile)
+
+	//Then
+	expectedRuleIds := []rules.RuleID{"ARule", "ZRule"}
+	if !reflect.DeepEqual(violatedRuleIds, expectedRuleIds) {
+		t.Errorf("Expected violated rules %v, got %v", expectedRuleIds, violatedRuleIds)
+	}
+}
+
+func TestFilterFindingsByRules_KeepsOnlyGivenRulesAndUpdatesCount(t *testing.T) {
+	//Given
+	finalResult := &finding.Output{
+		Count: 5,
+		Results: []finding.Finding{
+			{ID: "RuleA", Name: "First A"},
+			{ID: "RuleB"},
+			{ID: "RuleA", Name: "Second A"},
+			{ID: "RuleC"},
+			{ID: "RuleC"},
+		},
+	}
+
+	//When
+	filterFindingsByRules(finalResult, []rules.RuleID{"RuleA", "RuleC"})
+
+	//Then
+	expectedResults := []finding.Finding{
+		{ID: "RuleA", Name: "First A"},
+		{ID: "RuleA", Name: "Second A"},
+		{ID: "RuleC"},
+		{ID: "RuleC"},
+	}
+	if !reflect.DeepEqual(finalResult.Results, expectedResults) {
+		t.Errorf("Expected filtered results %+v, got %+v", expectedResults, finalResult.Results)
+	}
+	if finalResult.Count != 4 {
+		t.Errorf("Expected count 4 after filtering, got %d", finalResult.Count)
+	}
+}
+
+func TestFilterFindingsByRules_WhenNoRulesGiven_RemovesAllFindings(t *testing.T) {
+	//Given
+	finalResult := &finding.Output{
+		Count: 2,
+		Results: []finding.Finding{
+			{ID: "RuleA"},
+			{ID: "RuleB"},
+		},
+	}
+
+	//When
+	filterFindingsByRules(finalResult, []rules.RuleID{})
+
+	//Then
+	if len(finalResult.Results) != 0 {
+		t.Errorf("Expected no results after filtering, got %+v", finalResult.Results)
+	}
+	if finalResult.Count != 0 {
+		t.Errorf("Expected count 0 after filtering, got %d", finalResult.Count)
+	}
+}
+
 func TestCheckThresholdViolations_OutputIsSortedByRuleID(t *testing.T) {
 	//Given
 	finalResult := &finding.Output{


### PR DESCRIPTION
## Problem

When running with the CI/CD flag (`-j`), a single rule breaching its
`cicdmaxissues` threshold caused ASIST to print findings for **all** rules.
With e.g. 4 rules at 10 issues each and a cap of 10, introducing 2 new
violations printed ~40 findings, making the 2 new ones very hard to spot.

Additionally, findings JSON was written to stdout while the threshold
summary went to stderr, so output ordering was unpredictable across
platforms and CI log viewers.

## Changes

- **CI/CD filtering** — when thresholds are breached, the findings JSON now
  contains only the rules that exceeded their `cicdmaxissues` limit
  (`Count` reflects the filtered total). Exit code behavior is unchanged.
- **Single stream, fixed layout** — findings and the threshold summary are
  both written sequentially to stdout: issue details on top, summary at the
  very bottom.
- **Explicit pass message** — CI/CD runs with no breaches now end with
  `No rules exceeded their cicdmaxissues threshold.` instead of silence.
- Threshold logic split into `countFindingsPerRule`, `getViolatedRuleIds`
  and `filterFindingsByRules` helpers; `CheckThresholdViolations` keeps its
  existing signature and output format.

## No regression without the flag

Runs without `-j` are byte-for-byte unchanged: all findings printed, no
threshold text, exit 0.

## Testing

- New unit tests for breached-rule selection/sorting, filtering + count
  update, and the empty-rule-list edge case; full `go test ./...` passes.
- Verified end-to-end against `integrationtests/src`:
  - `-j` + breach → only breached rule's findings, summary at bottom,
    stderr empty, exit 1
  - `-j` + no breach → all findings + pass message, exit 0
  - no flag → unchanged output, exit 0